### PR TITLE
Add ID card number field with image and signature sizing

### DIFF
--- a/app/Http/Requests/StoreSmartCardRequest.php
+++ b/app/Http/Requests/StoreSmartCardRequest.php
@@ -27,13 +27,14 @@ class StoreSmartCardRequest extends FormRequest
             'department'        => ['required', 'string'],
             'designation'       => ['required', 'string'],
             'pf_number'         => 'required|numeric|unique:nu_smart_cards,pf_number',
+            'id_card_number'    => 'required|numeric|unique:nu_smart_cards,id_card_number',
             'mobile_number'     => ['required','numeric',new Phone(),'unique:nu_smart_cards,mobile_number'],
             'birth_date'        => 'required|date',
             'blood_id'          => 'required',
             'emergency_contact' => ['required','numeric', new Phone(),'unique:nu_smart_cards,emergency_contact'],
             'present_address'   => 'required|string',
-            'image'             => 'required|image|mimes:jpeg,png,jpg,webp|max:2048',
-            'signature'         => 'required|image|mimes:jpeg,png,jpg,webp|max:2048'
+            'image'             => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=531,height=649',
+            'signature'         => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=300,height=80'
         ];
     }
 }

--- a/app/Http/Requests/updateSmartCardRequest.php
+++ b/app/Http/Requests/updateSmartCardRequest.php
@@ -29,14 +29,15 @@ class updateSmartCardRequest extends FormRequest
             'department'        => ['required', 'string'],
             'designation'       => ['required', 'string'],
             'pf_number'         => ['required', 'numeric', Rule::unique('nu_smart_cards', 'pf_number')->ignore($this->nu_smart_card->id)],
+            'id_card_number'    => ['required', 'numeric', Rule::unique('nu_smart_cards', 'id_card_number')->ignore($this->nu_smart_card->id)],
             'mobile_number'     => ['required','numeric',new Phone(), Rule::unique('nu_smart_cards', 'mobile_number')->ignore($this->nu_smart_card->id)],
             'birth_date'        => 'required|date',
             'blood_id'          => 'required',
             'order_position'    => 'nullable|numeric',
             'emergency_contact' => ['required','numeric',new Phone(), Rule::unique('nu_smart_cards', 'emergency_contact')->ignore($this->nu_smart_card->id)],
             'present_address'   => 'required|string',
-            'image'             => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048'],
-            'signature'         => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048'],
+            'image'             => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=531,height=649'],
+            'signature'         => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=300,height=80'],
         ];
     }
 }

--- a/app/Models/NuSmartCard.php
+++ b/app/Models/NuSmartCard.php
@@ -15,7 +15,7 @@ class NuSmartCard extends Model
     public const SIGNATURE_UPLOAD_PATH = 'uploads/signature/';
 
     protected $fillable = [
-        'name', 'department', 'designation', 'pf_number',
+        'name', 'department', 'designation', 'pf_number', 'id_card_number',
         'birth_date', 'prl_date', 'mobile_number', 'blood_id', 'order_position',
         'present_address', 'emergency_contact', 'image', 'signature'
     ];
@@ -48,6 +48,7 @@ class NuSmartCard extends Model
             'department'        => $request->input('department'),
             'designation'       => $request->input('designation'),
             'pf_number'         => $request->input('pf_number'),
+            'id_card_number'    => $request->input('id_card_number'),
             'birth_date'        => $request->input('birth_date'),
             'prl_date'          => DateHelpers::calculatePRLDate($request->input('birth_date'), 60),
             'mobile_number'     => $request->input('mobile_number'),

--- a/database/migrations/2025_08_26_000001_add_id_card_number_to_nu_smart_cards_table.php
+++ b/database/migrations/2025_08_26_000001_add_id_card_number_to_nu_smart_cards_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('nu_smart_cards', function (Blueprint $table) {
+            $table->string('id_card_number')->nullable()->after('pf_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('nu_smart_cards', function (Blueprint $table) {
+            $table->dropColumn('id_card_number');
+        });
+    }
+};

--- a/resources/views/frontend/nuSmartCard/index.blade.php
+++ b/resources/views/frontend/nuSmartCard/index.blade.php
@@ -54,11 +54,16 @@
                                 </div>
                             </div>
 
-                            <div class="grid grid-cols-2 gap-3">
+                            <div class="grid grid-cols-3 gap-3">
                                 <div class="flex flex-col text-gray-700 dark:text-gray-200">
                                     <label class="mb-2 text-sm font-medium">PF No.</label>
                                     <input type="text" name="pf_number" placeholder="PF No." class="p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-800 dark:text-white">
                                     <span class="text-red-500 text-sm mt-1" id="pf_number-error"></span>
+                                </div>
+                                <div class="flex flex-col text-gray-700 dark:text-gray-200">
+                                    <label class="mb-2 text-sm font-medium">ID Card Number</label>
+                                    <input type="text" name="id_card_number" placeholder="ID Card Number" class="p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-800 dark:text-white">
+                                    <span class="text-red-500 text-sm mt-1" id="id_card_number-error"></span>
                                 </div>
                                 <div class="flex flex-col text-gray-700 dark:text-gray-200">
                                     <label class="mb-2 text-sm font-medium">Date of Birth</label>
@@ -104,7 +109,7 @@
                                     <img id="signaturePreview" class="mt-2 w-32 h-auto hidden"/>
                                 </div>
                                 <div class="flex flex-col">
-                                    <label class="mb-2 text-sm font-medium">Image PP Size (472 x 590)</label>
+                                    <label class="mb-2 text-sm font-medium">Image PP Size (45mm x 55mm)</label>
                                     <input type="file" name="image" placeholder="Upload passport size photo" class="p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-800 dark:text-white">
                                     <span class="text-red-500 text-sm mt-1" id="image-error"></span>
                                     <img id="profilePreview" class="mt-2 w-32 h-auto hidden" />
@@ -175,7 +180,7 @@
         }
 
         profileInput.addEventListener("change", function () {
-            handleImageSelection(this, 472 / 590, 472, 590);
+            handleImageSelection(this, 45 / 55, 531, 649);
         });
 
         signatureInput.addEventListener("change", function () {
@@ -190,8 +195,8 @@
 
         document.getElementById("cropImage").addEventListener("click", function () {
             if (cropper) {
-                const width = activeInput === profileInput ? 472 : 300;
-                const height = activeInput === profileInput ? 590 : 80;
+                const width = activeInput === profileInput ? 531 : 300;
+                const height = activeInput === profileInput ? 649 : 80;
                 const canvas = cropper.getCroppedCanvas({
                     width: width,
                     height: height,

--- a/resources/views/frontend/nuSmartCard/view.blade.php
+++ b/resources/views/frontend/nuSmartCard/view.blade.php
@@ -35,6 +35,10 @@
                 <td class="p-2">{{ $data->pf_number }}</td>
             </tr>
             <tr class="border-b border-gray-300 dark:border-gray-700">
+                <th class="p-2 w-50">ID Card Number:</th>
+                <td class="p-2">{{ $data->id_card_number }}</td>
+            </tr>
+            <tr class="border-b border-gray-300 dark:border-gray-700">
                 <th class="p-2 w-50">Birth Date:</th>
                 <td class="p-2">{{ $data->birth_date }}</td>
             </tr>

--- a/resources/views/nu-smart-card/create.blade.php
+++ b/resources/views/nu-smart-card/create.blade.php
@@ -41,12 +41,18 @@
                                 </div>
 
                                 <div class="mb-3">
+                                    <label for="id_card_number" class="form-label">ID Card Number</label>
+                                    <input type="text" id="id_card_number" name="id_card_number" placeholder="Enter ID card number" class="form-control">
+                                    <span class="text-red small" id="id_card_number-error"></span>
+                                </div>
+
+                                <div class="mb-3">
                                     <label for="present_address" class="form-label">Present Address</label>
                                     <textarea class="form-control" name="present_address" placeholder="Enter your present address" id="present_address" rows="5"></textarea>
                                     <span class="text-red small" id="present_address-error"></span>
                                 </div>
                                 <div class="mb-3">
-                                    <label for="image" class="form-label">Image</label>
+                                    <label for="image" class="form-label">Image (45mm x 55mm)</label>
                                     <input type="file" id="image" name="image" class="form-control">
                                     <span class="text-red small" id="image-error"></span>
                                     <img src="" id="profilePreview" alt="" class="w-25 img-thumbnail img-fluid">
@@ -164,7 +170,7 @@
             }
 
             profileInput.addEventListener("change", function () {
-                handleImageSelection(this, 472 / 590);
+                handleImageSelection(this, 45 / 55);
             });
 
             signatureInput.addEventListener("change", function () {
@@ -173,8 +179,8 @@
 
             document.getElementById("cropImage").addEventListener("click", function () {
                 if (cropper) {
-                    let width = activeInput === profileInput ? 472 : 300;
-                    let height = activeInput === profileInput ? 590 : 80;
+                    let width = activeInput === profileInput ? 531 : 300;
+                    let height = activeInput === profileInput ? 649 : 80;
                     const canvas = cropper.getCroppedCanvas({ width: width, height: height });
 
                     canvas.toBlob(blob => {

--- a/resources/views/nu-smart-card/edit.blade.php
+++ b/resources/views/nu-smart-card/edit.blade.php
@@ -45,12 +45,18 @@
                                 </div>
 
                                 <div class="mb-3">
+                                    <label for="id_card_number" class="form-label">ID Card Number</label>
+                                    <input type="text" id="id_card_number" name="id_card_number" class="form-control" value="{{$data->id_card_number}}">
+                                    <span class="text-red small" id="id_card_number-error"></span>
+                                </div>
+
+                                <div class="mb-3">
                                     <label for="present_address" class="form-label">Present Address</label>
                                     <textarea class="form-control" name="present_address" id="present_address" rows="5">{{$data->present_address}}</textarea>
                                     <span class="text-red small" id="present_address-error"></span>
                                 </div>
                                 <div class="mb-3">
-                                    <label for="image" class="form-label">Image</label>
+                                    <label for="image" class="form-label">Image (45mm x 55mm)</label>
                                     <input type="file" id="image" name="image" class="form-control">
                                     <span class="text-red small" id="image-error"></span>
                                     <img src="{{ asset('uploads/images/' . $data->image)  }}" id="profilePreview" alt="{{ $data->name }}" class="w-25 img-thumbnail img-fluid">
@@ -173,7 +179,7 @@
             }
 
             profileInput.addEventListener("change", function () {
-                handleImageSelection(this, 472 / 590);
+                handleImageSelection(this, 45 / 55);
             });
 
             signatureInput.addEventListener("change", function () {
@@ -182,8 +188,8 @@
 
             document.getElementById("cropImage").addEventListener("click", function () {
                 if (cropper) {
-                    let width = activeInput === profileInput ? 472 : 300;
-                    let height = activeInput === profileInput ? 590 : 80;
+                    let width = activeInput === profileInput ? 531 : 300;
+                    let height = activeInput === profileInput ? 649 : 80;
                     const canvas = cropper.getCroppedCanvas({ width: width, height: height });
 
                     canvas.toBlob(blob => {

--- a/resources/views/nu-smart-card/show.blade.php
+++ b/resources/views/nu-smart-card/show.blade.php
@@ -31,6 +31,10 @@
                                 <td>{{ $nuSmartCard->pf_number }}</td>
                             </tr>
                             <tr>
+                                <th>ID Card Number</th>
+                                <td>{{ $nuSmartCard->id_card_number }}</td>
+                            </tr>
+                            <tr>
                                 <th>Date of Birth</th>
                                 <td>{{ \App\Helpers\DateHelpers::dateFormat($nuSmartCard->birth_date) }}</td>
                             </tr>
@@ -59,7 +63,7 @@
                                 <td><img alt="" src="{{ asset('uploads/signature/' .$nuSmartCard->signature) }}"></td>
                             </tr>
                             <tr>
-                                <th>Signature</th>
+                                <th>Image</th>
                                 <td><img alt="" src="{{ asset('uploads/images/' .$nuSmartCard->image) }}"></td>
                             </tr>
                         </table>


### PR DESCRIPTION
## Summary
- add id_card_number column and update model
- validate image (45mm×55mm) and signature (300×80) dimensions
- expose ID card number and sizing notes in smart card views

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68adc3e3f3908326bb228d2e4d20422e