### PR TITLE
Expand crop dialog and improve image resolution

### DIFF
--- a/app/Http/Requests/StoreSmartCardRequest.php
+++ b/app/Http/Requests/StoreSmartCardRequest.php
@@ -33,8 +33,8 @@ class StoreSmartCardRequest extends FormRequest
             'blood_id'          => 'required',
             'emergency_contact' => ['required','numeric', new Phone(),'unique:nu_smart_cards,emergency_contact'],
             'present_address'   => 'required|string',
-            'image'             => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=531,height=649',
-            'signature'         => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=300,height=80'
+            'image'             => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=810,height=990',
+            'signature'         => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=600,height=160'
         ];
     }
 }

--- a/app/Http/Requests/updateSmartCardRequest.php
+++ b/app/Http/Requests/updateSmartCardRequest.php
@@ -36,8 +36,8 @@ class updateSmartCardRequest extends FormRequest
             'order_position'    => 'nullable|numeric',
             'emergency_contact' => ['required','numeric',new Phone(), Rule::unique('nu_smart_cards', 'emergency_contact')->ignore($this->nu_smart_card->id)],
             'present_address'   => 'required|string',
-            'image'             => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=531,height=649'],
-            'signature'         => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=300,height=80'],
+            'image'             => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=810,height=990'],
+            'signature'         => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=600,height=160'],
         ];
     }
 }

--- a/resources/views/frontend/nuSmartCard/index.blade.php
+++ b/resources/views/frontend/nuSmartCard/index.blade.php
@@ -145,8 +145,8 @@
         cropperModal.id = "cropperModal";
         cropperModal.className = "fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 hidden";
         cropperModal.innerHTML = `
-            <div class="bg-white p-4 rounded-lg shadow-md">
-                <img id="cropperPreview" class="max-w-3xl h-auto" />
+            <div class="bg-white p-6 rounded-lg shadow-md max-w-4xl w-full">
+                <img id="cropperPreview" class="w-full h-auto" />
                 <div class="flex justify-end mt-4">
                     <button id="cropImage" class="bg-green-500 text-white p-2 rounded-md mr-2">Crop</button>
                     <button id="cancelCrop" class="bg-red-500 text-white p-2 rounded-md">Cancel</button>
@@ -180,11 +180,11 @@
         }
 
         profileInput.addEventListener("change", function () {
-            handleImageSelection(this, 45 / 55, 531, 649);
+            handleImageSelection(this, 45 / 55, 810, 990);
         });
 
         signatureInput.addEventListener("change", function () {
-            handleImageSelection(this, 300 / 80, 300, 80);
+            handleImageSelection(this, 300 / 80, 600, 160);
         });
 
         document.getElementById("cancelCrop").addEventListener("click", function () {
@@ -195,8 +195,8 @@
 
         document.getElementById("cropImage").addEventListener("click", function () {
             if (cropper) {
-                const width = activeInput === profileInput ? 531 : 300;
-                const height = activeInput === profileInput ? 649 : 80;
+                const width = activeInput === profileInput ? 810 : 600;
+                const height = activeInput === profileInput ? 990 : 160;
                 const canvas = cropper.getCroppedCanvas({
                     width: width,
                     height: height,

--- a/resources/views/nu-smart-card/create.blade.php
+++ b/resources/views/nu-smart-card/create.blade.php
@@ -113,7 +113,7 @@
 
     <!-- Fullscreen Bootstrap Modal for Image Cropping -->
     <div class="modal fade" id="cropperModal" tabindex="-1" aria-labelledby="cropperModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
+        <div class="modal-dialog modal-xl">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Crop Image</h5>
@@ -121,7 +121,7 @@
                 </div>
                 <div class="modal-body p-0 d-flex justify-content-center align-items-center">
                     <div class="w-auto h-auto d-flex justify-content-center align-items-center">
-                        <img id="cropperPreview" class="object-fit-fill"/>
+                        <img id="cropperPreview" class="img-fluid"/>
                     </div>
                 </div>
                 <div class="modal-footer d-flex justify-content-center">
@@ -179,8 +179,8 @@
 
             document.getElementById("cropImage").addEventListener("click", function () {
                 if (cropper) {
-                    let width = activeInput === profileInput ? 531 : 300;
-                    let height = activeInput === profileInput ? 649 : 80;
+                    let width = activeInput === profileInput ? 810 : 600;
+                    let height = activeInput === profileInput ? 990 : 160;
                     const canvas = cropper.getCroppedCanvas({ width: width, height: height });
 
                     canvas.toBlob(blob => {

--- a/resources/views/nu-smart-card/edit.blade.php
+++ b/resources/views/nu-smart-card/edit.blade.php
@@ -120,7 +120,7 @@
 
     <!-- Fullscreen Bootstrap Modal for Image Cropping -->
     <div class="modal fade" id="cropperModal" tabindex="-1" aria-labelledby="cropperModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
+        <div class="modal-dialog modal-xl">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Crop Image</h5>
@@ -128,7 +128,7 @@
                 </div>
                 <div class="modal-body p-0 d-flex justify-content-center align-items-center">
                     <div class="w-auto h-auto d-flex justify-content-center align-items-center">
-                        <img id="cropperPreview" class="object-fit-fill"/>
+                        <img id="cropperPreview" class="img-fluid"/>
                     </div>
                 </div>
                 <div class="modal-footer d-flex justify-content-center">
@@ -188,8 +188,8 @@
 
             document.getElementById("cropImage").addEventListener("click", function () {
                 if (cropper) {
-                    let width = activeInput === profileInput ? 531 : 300;
-                    let height = activeInput === profileInput ? 649 : 80;
+                    let width = activeInput === profileInput ? 810 : 600;
+                    let height = activeInput === profileInput ? 990 : 160;
                     const canvas = cropper.getCroppedCanvas({ width: width, height: height });
 
                     canvas.toBlob(blob => {


### PR DESCRIPTION
## Summary
- enlarge profile/signature cropper dialogs for easier editing
- boost cropped profile image and signature resolution
- update backend validation to match higher dimensions

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer install` *(fails: requires GitHub credentials)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68add2364f7c8326b48b4e99871bd6fb