### PR TITLE
Expand cropper container size

### DIFF
--- a/resources/views/frontend/nuSmartCard/index.blade.php
+++ b/resources/views/frontend/nuSmartCard/index.blade.php
@@ -17,8 +17,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" ></script>
     <style type="text/css">
         #cropperModal img {
-            max-width: 90vw;  /* Ensure the image fits within the viewport width */
-            max-height: 70vh; /* Ensure it fits within the viewport height */
+            width: 90vw;           /* Expand image to larger viewport width */
+            max-width: 90vw;
+            max-height: 85vh;     /* Allow a taller crop area */
             display: block;
             margin: auto;
         }
@@ -145,7 +146,7 @@
         cropperModal.id = "cropperModal";
         cropperModal.className = "fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 hidden";
         cropperModal.innerHTML = `
-            <div class="bg-white p-6 rounded-lg shadow-md max-w-4xl w-full">
+            <div class="bg-white p-6 rounded-lg shadow-md w-full" style="max-width:90vw;">
                 <img id="cropperPreview" class="w-full h-auto" />
                 <div class="flex justify-end mt-4">
                     <button id="cropImage" class="bg-green-500 text-white p-2 rounded-md mr-2">Crop</button>

--- a/resources/views/nu-smart-card/create.blade.php
+++ b/resources/views/nu-smart-card/create.blade.php
@@ -3,6 +3,17 @@
 @section('css')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.13/cropper.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/izitoast/dist/css/iziToast.min.css">
+    <style>
+        #cropperModal .modal-dialog {
+            max-width: 90vw;
+        }
+
+        #cropperModal img {
+            width: 90vw;
+            max-width: 90vw;
+            max-height: 85vh;
+        }
+    </style>
 @endsection
 @section('content')
     <div class="row row-cols-lg-1 gx-3">

--- a/resources/views/nu-smart-card/edit.blade.php
+++ b/resources/views/nu-smart-card/edit.blade.php
@@ -3,6 +3,17 @@
 @section('css')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.13/cropper.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/izitoast/dist/css/iziToast.min.css">
+    <style>
+        #cropperModal .modal-dialog {
+            max-width: 90vw;
+        }
+
+        #cropperModal img {
+            width: 90vw;
+            max-width: 90vw;
+            max-height: 85vh;
+        }
+    </style>
 @endsection
 @section('content')
     <div class="row row-cols-lg-1 gx-3">


### PR DESCRIPTION
## Summary
- enlarge Cropper.js preview images for easier passport and signature cropping
- allow modal dialogs to grow to 90vw and taller crop areas

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68add776ecb88326a2bfa4e338728f50