### PR TITLE
Add department and designation support to smart card

### DIFF
--- a/app/Http/Controllers/DepartmentController.php
+++ b/app/Http/Controllers/DepartmentController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Department;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class DepartmentController extends Controller
+{
+    public function index(): View
+    {
+        $departments = Department::latest()->paginate(10);
+        return view('dashboard.departments.index', compact('departments'));
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate(['name' => 'required|string|max:255']);
+        Department::create($request->only('name'));
+        return back()->with('success', 'Department created successfully');
+    }
+
+    public function update(Request $request, Department $department): RedirectResponse
+    {
+        $request->validate(['name' => 'required|string|max:255']);
+        $department->update($request->only('name'));
+        return back()->with('success', 'Department updated successfully');
+    }
+
+    public function destroy(Department $department): RedirectResponse
+    {
+        $department->delete();
+        return back()->with('success', 'Department deleted successfully');
+    }
+}

--- a/app/Http/Controllers/DesignationController.php
+++ b/app/Http/Controllers/DesignationController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Designation;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class DesignationController extends Controller
+{
+    public function index(): View
+    {
+        $designations = Designation::latest()->paginate(10);
+        return view('dashboard.designations.index', compact('designations'));
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate(['name' => 'required|string|max:255']);
+        Designation::create($request->only('name'));
+        return back()->with('success', 'Designation created successfully');
+    }
+
+    public function update(Request $request, Designation $designation): RedirectResponse
+    {
+        $request->validate(['name' => 'required|string|max:255']);
+        $designation->update($request->only('name'));
+        return back()->with('success', 'Designation updated successfully');
+    }
+
+    public function destroy(Designation $designation): RedirectResponse
+    {
+        $designation->delete();
+        return back()->with('success', 'Designation deleted successfully');
+    }
+}

--- a/app/Http/Controllers/NuSmartCardController.php
+++ b/app/Http/Controllers/NuSmartCardController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreSmartCardRequest;
 use App\Models\BloodGroup;
 use App\Models\NuSmartCard;
+use App\Models\Department;
+use App\Models\Designation;
 use Carbon\Carbon;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
@@ -23,7 +25,9 @@ class NuSmartCardController extends Controller
     public function index()
     {
         $bloods = BloodGroup::where('status', 1)->get();
-        return view('frontend.nuSmartCard.index', compact('bloods'));
+        $departments = Department::all();
+        $designations = Designation::all();
+        return view('frontend.nuSmartCard.index', compact('bloods', 'departments', 'designations'));
     }
 
     /**
@@ -117,5 +121,15 @@ class NuSmartCardController extends Controller
     public function destroy(NuSmartCard $nuSmartCard)
     {
         //
+    }
+    public function search(Request $request): JsonResponse
+    {
+        $term = $request->get('q');
+        $results = NuSmartCard::with(["department", "designation"])
+            ->where("name", "like", "%" . $term . "%")
+            ->orWhere("pf_number", "like", "%" . $term . "%")
+            ->limit(10)
+            ->get();
+        return response()->json($results);
     }
 }

--- a/app/Http/Requests/StoreSmartCardRequest.php
+++ b/app/Http/Requests/StoreSmartCardRequest.php
@@ -24,8 +24,8 @@ class StoreSmartCardRequest extends FormRequest
     {
         return [
             'name'              => ['required', 'string'],
-            'department'        => ['required', 'string'],
-            'designation'       => ['required', 'string'],
+            'department_id'     => ['required', 'integer', 'exists:departments,id'],
+            'designation_id'    => ['required', 'integer', 'exists:designations,id'],
             'pf_number'         => 'required|numeric|unique:nu_smart_cards,pf_number',
             'id_card_number'    => 'required|numeric|unique:nu_smart_cards,id_card_number',
             'mobile_number'     => ['required','numeric',new Phone(),'unique:nu_smart_cards,mobile_number'],

--- a/app/Http/Requests/updateSmartCardRequest.php
+++ b/app/Http/Requests/updateSmartCardRequest.php
@@ -26,8 +26,8 @@ class updateSmartCardRequest extends FormRequest
     {
         return [
             'name'              => ['required', 'string'],
-            'department'        => ['required', 'string'],
-            'designation'       => ['required', 'string'],
+            'department_id'     => ['required', 'integer', 'exists:departments,id'],
+            'designation_id'    => ['required', 'integer', 'exists:designations,id'],
             'pf_number'         => ['required', 'numeric', Rule::unique('nu_smart_cards', 'pf_number')->ignore($this->nu_smart_card->id)],
             'id_card_number'    => ['required', 'numeric', Rule::unique('nu_smart_cards', 'id_card_number')->ignore($this->nu_smart_card->id)],
             'mobile_number'     => ['required','numeric',new Phone(), Rule::unique('nu_smart_cards', 'mobile_number')->ignore($this->nu_smart_card->id)],

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Department extends Model
+{
+    protected $fillable = ['name'];
+
+    public function smartCards(): HasMany
+    {
+        return $this->hasMany(NuSmartCard::class);
+    }
+}

--- a/app/Models/Designation.php
+++ b/app/Models/Designation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Designation extends Model
+{
+    protected $fillable = ['name'];
+
+    public function smartCards(): HasMany
+    {
+        return $this->hasMany(NuSmartCard::class);
+    }
+}

--- a/app/Models/NuSmartCard.php
+++ b/app/Models/NuSmartCard.php
@@ -15,7 +15,7 @@ class NuSmartCard extends Model
     public const SIGNATURE_UPLOAD_PATH = 'uploads/signature/';
 
     protected $fillable = [
-        'name', 'department', 'designation', 'pf_number', 'id_card_number',
+        'name', 'department_id', 'designation_id', 'pf_number', 'id_card_number',
         'birth_date', 'prl_date', 'mobile_number', 'blood_id', 'order_position',
         'present_address', 'emergency_contact', 'image', 'signature'
     ];
@@ -45,8 +45,8 @@ class NuSmartCard extends Model
 
         $data = [
             'name'              => $request->input('name'),
-            'department'        => $request->input('department'),
-            'designation'       => $request->input('designation'),
+            'department_id'     => $request->input('department_id'),
+            'designation_id'    => $request->input('designation_id'),
             'pf_number'         => $request->input('pf_number'),
             'id_card_number'    => $request->input('id_card_number'),
             'birth_date'        => $request->input('birth_date'),
@@ -108,5 +108,14 @@ class NuSmartCard extends Model
     public function blood(): BelongsTo
     {
         return $this->belongsTo('App\Models\BloodGroup', 'blood_id');
+    }
+    public function department(): BelongsTo
+    {
+        return $this->belongsTo(Department::class);
+    }
+
+    public function designation(): BelongsTo
+    {
+        return $this->belongsTo(Designation::class);
     }
 }

--- a/database/migrations/2025_09_05_000000_create_departments_table.php
+++ b/database/migrations/2025_09_05_000000_create_departments_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('departments', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('departments');
+    }
+};

--- a/database/migrations/2025_09_05_000001_create_designations_table.php
+++ b/database/migrations/2025_09_05_000001_create_designations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('designations', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('designations');
+    }
+};

--- a/database/migrations/2025_09_05_000002_add_department_and_designation_id_to_nu_smart_cards_table.php
+++ b/database/migrations/2025_09_05_000002_add_department_and_designation_id_to_nu_smart_cards_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('nu_smart_cards', function (Blueprint $table) {
+            $table->foreignId('department_id')->nullable()->constrained('departments');
+            $table->foreignId('designation_id')->nullable()->constrained('designations');
+            $table->dropColumn(['department', 'designation']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('nu_smart_cards', function (Blueprint $table) {
+            $table->string('department')->nullable();
+            $table->string('designation')->nullable();
+            $table->dropConstrainedForeignId('department_id');
+            $table->dropConstrainedForeignId('designation_id');
+        });
+    }
+};

--- a/resources/views/dashboard/departments/index.blade.php
+++ b/resources/views/dashboard/departments/index.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts.vertical', ['subtitle' => 'Departments'])
+@section('content')
+    @include('layouts.partials/page-title', ['title' => 'Nu Module', 'subtitle' => 'Departments'])
+    <div class="card">
+        <div class="card-header">
+            <div class="flex-box justify-content-between">
+                <h5 class="card-title">Departments</h5>
+                <button type="button" class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#departmentModal">Add New</button>
+            </div>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-centered">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Name</th>
+                            <th class="text-center">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($departments as $department)
+                            <tr>
+                                <td>{{ $departments->firstItem()+$loop->index }}</td>
+                                <td>{{ $department->name }}</td>
+                                <td class="text-center">
+                                    <form method="POST" action="{{ route('departments.destroy', $department) }}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button class="btn btn-sm btn-danger">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr><td colspan="3" class="text-center">No data found</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+                {{ $departments->links('pagination::bootstrap-5') }}
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="departmentModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <form method="POST" action="{{ route('departments.store') }}" class="modal-content">
+                @csrf
+                <div class="modal-header"><h5 class="modal-title">Add Department</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Name</label>
+                        <input type="text" name="name" class="form-control" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/dashboard/designations/index.blade.php
+++ b/resources/views/dashboard/designations/index.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts.vertical', ['subtitle' => 'Designations'])
+@section('content')
+    @include('layouts.partials/page-title', ['title' => 'Nu Module', 'subtitle' => 'Designations'])
+    <div class="card">
+        <div class="card-header">
+            <div class="flex-box justify-content-between">
+                <h5 class="card-title">Designations</h5>
+                <button type="button" class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#designationModal">Add New</button>
+            </div>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-centered">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Name</th>
+                            <th class="text-center">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($designations as $designation)
+                            <tr>
+                                <td>{{ $designations->firstItem()+$loop->index }}</td>
+                                <td>{{ $designation->name }}</td>
+                                <td class="text-center">
+                                    <form method="POST" action="{{ route('designations.destroy', $designation) }}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button class="btn btn-sm btn-danger">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr><td colspan="3" class="text-center">No data found</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+                {{ $designations->links('pagination::bootstrap-5') }}
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="designationModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <form method="POST" action="{{ route('designations.store') }}" class="modal-content">
+                @csrf
+                <div class="modal-header"><h5 class="modal-title">Add Designation</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Name</label>
+                        <input type="text" name="name" class="form-control" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/frontend/nuSmartCard/index.blade.php
+++ b/resources/views/frontend/nuSmartCard/index.blade.php
@@ -33,6 +33,10 @@
             <main class="p-4">
                 <div class="grid gap-6 lg:grid-cols-1 lg:gap-8">
                     <div class="flex flex-col col-span-1 p-6 bg-white dark:bg-gray-900 rounded-lg shadow-md">
+                        <div class="mb-4">
+                            <input type="text" id="live-search" placeholder="Search Smart Card" class="w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-800 dark:text-white">
+                            <ul id="search-results" class="mt-2"></ul>
+                        </div>
                         <form class="flex flex-col gap-4" id="ajax-form" enctype="multipart/form-data">
                             <div class="flex flex-col text-gray-700 dark:text-gray-200">
                                 <label class="mb-2 text-sm font-medium">Name</label>
@@ -42,16 +46,23 @@
                             <div class="grid grid-cols-2 gap-3">
                                 <div class="flex flex-col text-gray-700 dark:text-gray-200">
                                     <label class="mb-2 text-sm font-medium">Department</label>
-                                    <select name="department" class="p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-800 dark:text-white">
+                                    <select name="department_id" class="p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-800 dark:text-white">
                                         <option value="">Select Department</option>
-                                        <option value="College Inspection">College Inspection</option>
+                                        @foreach($departments as $department)
+                                            <option value="{{ $department->id }}">{{ $department->name }}</option>
+                                        @endforeach
                                     </select>
-                                    <span class="text-red-500 text-sm mt-1" id="department-error"></span>
+                                    <span class="text-red-500 text-sm mt-1" id="department_id-error"></span>
                                 </div>
                                 <div class="flex flex-col text-gray-700 dark:text-gray-200">
                                     <label class="mb-2 text-sm font-medium">Designation</label>
-                                    <input type="text" name="designation" placeholder="Enter your designation" class="p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-800 dark:text-white">
-                                    <span class="text-red-500 text-sm mt-1" id="designation-error"></span>
+                                    <select name="designation_id" class="p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-800 dark:text-white">
+                                        <option value="">Select Designation</option>
+                                        @foreach($designations as $designation)
+                                            <option value="{{ $designation->id }}">{{ $designation->name }}</option>
+                                        @endforeach
+                                    </select>
+                                    <span class="text-red-500 text-sm mt-1" id="designation_id-error"></span>
                                 </div>
                             </div>
 
@@ -140,6 +151,15 @@
         let cropper, activeInput;
         let croppedProfileBlob = null;
         let croppedSignatureBlob = null;
+
+        $('#live-search').on('keyup', function(){
+            let q = $(this).val();
+            if(q.length < 2){ $('#search-results').empty(); return; }
+            $.get('/nu-smart-card/search', {q:q}, function(data){
+                let html = data.map(item => `<li>${item.name} - ${(item.designation ? item.designation.name : '')}</li>`).join('');
+                $('#search-results').html(html);
+            });
+        });
 
         // ✅ Cropper Modal Setup
         const cropperModal = document.createElement("div");

--- a/resources/views/nu-smart-card/create.blade.php
+++ b/resources/views/nu-smart-card/create.blade.php
@@ -34,15 +34,25 @@
                                 </div>
 
                                 <div class="mb-3">
-                                    <label for="department" class="form-label">Department</label>
-                                    <input type="text" id="department" name="department" class="form-control" placeholder="Department">
-                                    <span class="text-red small" id="department-error"></span>
+                                    <label for="department_id" class="form-label">Department</label>
+                                    <select id="department_id" name="department_id" class="form-select">
+                                        <option value="">Select Department</option>
+                                        @foreach($departments as $department)
+                                            <option value="{{ $department->id }}">{{ $department->name }}</option>
+                                        @endforeach
+                                    </select>
+                                    <span class="text-red small" id="department_id-error"></span>
                                 </div>
 
                                 <div class="mb-3">
-                                    <label for="designation" class="form-label">Designation</label>
-                                    <input type="text" id="designation" name="designation" placeholder="Designation" class="form-control">
-                                    <span class="text-red small" id="designation-error"></span>
+                                    <label for="designation_id" class="form-label">Designation</label>
+                                    <select id="designation_id" name="designation_id" class="form-select">
+                                        <option value="">Select Designation</option>
+                                        @foreach($designations as $designation)
+                                            <option value="{{ $designation->id }}">{{ $designation->name }}</option>
+                                        @endforeach
+                                    </select>
+                                    <span class="text-red small" id="designation_id-error"></span>
                                 </div>
 
                                 <div class="mb-3">

--- a/resources/views/nu-smart-card/edit.blade.php
+++ b/resources/views/nu-smart-card/edit.blade.php
@@ -37,16 +37,25 @@
                                 </div>
 
                                 <div class="mb-3">
-                                    <label for="department" class="form-label">Department</label>
-                                    <input type="text" id="department" value="{{$data->department}}" name="department" class="form-control"
-                                           placeholder="Department">
-                                    <span class="text-red small" id="department-error"></span>
+                                    <label for="department_id" class="form-label">Department</label>
+                                    <select id="department_id" name="department_id" class="form-select">
+                                        <option value="">Select Department</option>
+                                        @foreach($departments as $department)
+                                            <option value="{{ $department->id }}" {{ $data->department_id == $department->id ? 'selected' : '' }}>{{ $department->name }}</option>
+                                        @endforeach
+                                    </select>
+                                    <span class="text-red small" id="department_id-error"></span>
                                 </div>
 
                                 <div class="mb-3">
-                                    <label for="designation" class="form-label">Designation</label>
-                                    <input type="text" id="designation" name="designation" class="form-control" value="{{$data->designation}}">
-                                    <span class="text-red small" id="designation-error"></span>
+                                    <label for="designation_id" class="form-label">Designation</label>
+                                    <select id="designation_id" name="designation_id" class="form-select">
+                                        <option value="">Select Designation</option>
+                                        @foreach($designations as $designation)
+                                            <option value="{{ $designation->id }}" {{ $data->designation_id == $designation->id ? 'selected' : '' }}>{{ $designation->name }}</option>
+                                        @endforeach
+                                    </select>
+                                    <span class="text-red small" id="designation_id-error"></span>
                                 </div>
 
                                 <div class="mb-3">

--- a/resources/views/nu-smart-card/index.blade.php
+++ b/resources/views/nu-smart-card/index.blade.php
@@ -32,7 +32,7 @@
                             <tr>
                                 <th scope="row">{{ $data->firstItem()+$loop->index }}</th>
                                 <td>{{ $nu->name }}</td>
-                                <td>{{ $nu->designation }}</td>
+                                <td>{{ $nu->designation?->name }}</td>
                                 <td>{{ $nu->created_at->toDateString() }}</td>
                                 <td><img class="img-thumbnail img-fluid rounded mx-auto d-block w-25" alt="image" src="{!! asset('uploads/images/' . $nu->image)  !!}"> </td>
                                 <td class="text-center">

--- a/resources/views/nu-smart-card/show.blade.php
+++ b/resources/views/nu-smart-card/show.blade.php
@@ -20,11 +20,11 @@
                             </tr>
                             <tr>
                                 <th>Designation</th>
-                                <td>{{ $nuSmartCard->designation }}</td>
+                                <td>{{ $nuSmartCard->designation?->name }}</td>
                             </tr>
                             <tr>
                                 <th>Department</th>
-                                <td>{{ $nuSmartCard->department }}</td>
+                                <td>{{ $nuSmartCard->department?->name }}</td>
                             </tr>
                             <tr>
                                 <th>PF No</th>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\FrontendController;
 use App\Http\Controllers\MenuController;
 use App\Http\Controllers\NuSmartCardController;
+use App\Http\Controllers\DepartmentController;
+use App\Http\Controllers\DesignationController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\RoutingController;
 use Illuminate\Support\Facades\Route;
@@ -28,10 +30,14 @@ Route::group(['prefix' => '/dashboard', 'middleware' => 'auth'], function () {
     Route::resource('nu-smart-card', DashboardController::class);
     Route::get('view-pdf', [DashboardController::class, 'getPdfData'])->name('view-pdf');
     Route::get('single-pdf/{id}', [DashboardController::class, 'getSinglePdfData'])->name('single-pdf');
+    Route::get('export-word', [DashboardController::class, 'exportWord'])->name('export-word');
 
     // Blood Group
     Route::resource('blood-group', BloodGroupController::class);
     Route::post('/blood-group/{id}/update-status', [BloodGroupController::class, 'updateStatus'])->name('blood-group.update-status');
+
+    Route::resource('departments', DepartmentController::class);
+    Route::resource('designations', DesignationController::class);
 
     // Menu route
     Route::get('manage-menus',[MenuController::class, 'index'])->name('manage-menus');
@@ -49,6 +55,7 @@ Route::group(['prefix' => '/dashboard', 'middleware' => 'auth'], function () {
 
 Route::get('/nu-smart-card', [NuSmartCardController::class, 'index']);
 Route::post('/nu-smart-card', [NuSmartCardController::class, 'store_data'])->name('nu-smart-card.store_data');
+Route::get('/nu-smart-card/search', [NuSmartCardController::class, 'search'])->name('nu-smart-card.search');
 Route::get('/view-data', [NuSmartCardController::class, 'viewData'])->name('view-data');
 
 


### PR DESCRIPTION
## Summary
- add Department and Designation models, migrations, controllers, and views
- link Nu Smart Card entries to departments and designations
- provide Word export and live search for Smart Cards

## Testing
- `php -l app/Models/NuSmartCard.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adea9b6c388326a21905a9c4c21e75