### PR TITLE
Add department and designation links to Nu Smart Card menu

### DIFF
--- a/resources/views/layouts/partials/sidebar.blade.php
+++ b/resources/views/layouts/partials/sidebar.blade.php
@@ -47,6 +47,12 @@
                           <li class="sub-nav-item">
                               <a class="sub-nav-link" href="{{ route ('blood-group.index') }}">Blood Group</a>
                           </li>
+                          <li class="sub-nav-item">
+                              <a class="sub-nav-link" href="{{ route('departments.index') }}">Department</a>
+                          </li>
+                          <li class="sub-nav-item">
+                              <a class="sub-nav-link" href="{{ route('designations.index') }}">Designation</a>
+                          </li>
                       </ul>
                   </div>
               </li>


### PR DESCRIPTION
## Summary
- Add Department and Designation links under the Nu Smart Card sidebar menu

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: GitHub 403 when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aded1e85c48326a16467f4284f64ed