### PR TITLE
Handle dependent smart card constraints

### DIFF
--- a/app/Http/Controllers/DepartmentController.php
+++ b/app/Http/Controllers/DepartmentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Department;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
@@ -31,7 +32,11 @@ class DepartmentController extends Controller
 
     public function destroy(Department $department): RedirectResponse
     {
-        $department->delete();
-        return back()->with('success', 'Department deleted successfully');
+        try {
+            $department->delete();
+            return back()->with('success', 'Department deleted successfully');
+        } catch (QueryException $e) {
+            return back()->with('error', 'Department cannot be deleted because it is associated with an existing smart card.');
+        }
     }
 }

--- a/app/Http/Controllers/DesignationController.php
+++ b/app/Http/Controllers/DesignationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Designation;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
@@ -31,7 +32,11 @@ class DesignationController extends Controller
 
     public function destroy(Designation $designation): RedirectResponse
     {
-        $designation->delete();
-        return back()->with('success', 'Designation deleted successfully');
+        try {
+            $designation->delete();
+            return back()->with('success', 'Designation deleted successfully');
+        } catch (QueryException $e) {
+            return back()->with('error', 'Designation cannot be deleted because it is associated with an existing smart card.');
+        }
     }
 }

--- a/database/migrations/2025_09_05_000002_add_department_and_designation_id_to_nu_smart_cards_table.php
+++ b/database/migrations/2025_09_05_000002_add_department_and_designation_id_to_nu_smart_cards_table.php
@@ -9,8 +9,14 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('nu_smart_cards', function (Blueprint $table) {
-            $table->foreignId('department_id')->nullable()->constrained('departments');
-            $table->foreignId('designation_id')->nullable()->constrained('designations');
+            $table->foreignId('department_id')
+                ->nullable()
+                ->constrained('departments')
+                ->nullOnDelete();
+            $table->foreignId('designation_id')
+                ->nullable()
+                ->constrained('designations')
+                ->nullOnDelete();
             $table->dropColumn(['department', 'designation']);
         });
     }


### PR DESCRIPTION
## Summary
- prevent foreign key errors when deleting departments or designations
- display user-friendly errors when departments or designations are linked to smart cards

## Testing
- `php artisan test` *(fails: require(/workspace/nu-project-Laravel/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68adeeec895083268a43ca35b3885813