### PR TITLE
Add edit modals and live search for departments and designations

### DIFF
--- a/resources/views/dashboard/departments/index.blade.php
+++ b/resources/views/dashboard/departments/index.blade.php
@@ -9,8 +9,11 @@
             </div>
         </div>
         <div class="card-body">
-            <div class="table-responsive">
-                <table class="table table-centered">
+                <div class="mb-3">
+                    <input type="text" id="department-search" class="form-control" placeholder="Search...">
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-centered" id="department-table">
                     <thead>
                         <tr>
                             <th>#</th>
@@ -24,11 +27,14 @@
                                 <td>{{ $departments->firstItem()+$loop->index }}</td>
                                 <td>{{ $department->name }}</td>
                                 <td class="text-center">
-                                    <form method="POST" action="{{ route('departments.destroy', $department) }}">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button class="btn btn-sm btn-danger">Delete</button>
-                                    </form>
+                                    <div class="d-flex justify-content-center gap-2">
+                                        <button type="button" class="btn btn-sm btn-warning" data-bs-toggle="modal" data-bs-target="#departmentModal" data-url="{{ route('departments.update', $department) }}" data-name="{{ $department->name }}">Edit</button>
+                                        <form method="POST" action="{{ route('departments.destroy', $department) }}">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button class="btn btn-sm btn-danger">Delete</button>
+                                        </form>
+                                    </div>
                                 </td>
                             </tr>
                         @empty
@@ -59,4 +65,34 @@
             </form>
         </div>
     </div>
+    <script>
+        $(function () {
+            var createUrl = "{{ route('departments.store') }}";
+            $('#departmentModal').on('show.bs.modal', function (event) {
+                var button = $(event.relatedTarget);
+                var url = button.data('url');
+                var name = button.data('name');
+                var modal = $(this);
+                var form = modal.find('form');
+                if (url) {
+                    modal.find('.modal-title').text('Edit Department');
+                    form.attr('action', url);
+                    form.append('<input type="hidden" name="_method" value="PUT">');
+                    form.find('input[name="name"]').val(name);
+                } else {
+                    modal.find('.modal-title').text('Add Department');
+                    form.attr('action', createUrl);
+                    form.find('input[name="_method"]').remove();
+                    form.find('input[name="name"]').val('');
+                }
+            });
+
+            $('#department-search').on('keyup', function () {
+                var value = $(this).val().toLowerCase();
+                $('#department-table tbody tr').filter(function () {
+                    $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1);
+                });
+            });
+        });
+    </script>
 @endsection

--- a/resources/views/dashboard/designations/index.blade.php
+++ b/resources/views/dashboard/designations/index.blade.php
@@ -9,8 +9,11 @@
             </div>
         </div>
         <div class="card-body">
-            <div class="table-responsive">
-                <table class="table table-centered">
+                <div class="mb-3">
+                    <input type="text" id="designation-search" class="form-control" placeholder="Search...">
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-centered" id="designation-table">
                     <thead>
                         <tr>
                             <th>#</th>
@@ -24,11 +27,14 @@
                                 <td>{{ $designations->firstItem()+$loop->index }}</td>
                                 <td>{{ $designation->name }}</td>
                                 <td class="text-center">
-                                    <form method="POST" action="{{ route('designations.destroy', $designation) }}">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button class="btn btn-sm btn-danger">Delete</button>
-                                    </form>
+                                    <div class="d-flex justify-content-center gap-2">
+                                        <button type="button" class="btn btn-sm btn-warning" data-bs-toggle="modal" data-bs-target="#designationModal" data-url="{{ route('designations.update', $designation) }}" data-name="{{ $designation->name }}">Edit</button>
+                                        <form method="POST" action="{{ route('designations.destroy', $designation) }}">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button class="btn btn-sm btn-danger">Delete</button>
+                                        </form>
+                                    </div>
                                 </td>
                             </tr>
                         @empty
@@ -59,4 +65,34 @@
             </form>
         </div>
     </div>
+    <script>
+        $(function () {
+            var createUrl = "{{ route('designations.store') }}";
+            $('#designationModal').on('show.bs.modal', function (event) {
+                var button = $(event.relatedTarget);
+                var url = button.data('url');
+                var name = button.data('name');
+                var modal = $(this);
+                var form = modal.find('form');
+                if (url) {
+                    modal.find('.modal-title').text('Edit Designation');
+                    form.attr('action', url);
+                    form.append('<input type="hidden" name="_method" value="PUT">');
+                    form.find('input[name="name"]').val(name);
+                } else {
+                    modal.find('.modal-title').text('Add Designation');
+                    form.attr('action', createUrl);
+                    form.find('input[name="_method"]').remove();
+                    form.find('input[name="name"]').val('');
+                }
+            });
+
+            $('#designation-search').on('keyup', function () {
+                var value = $(this).val().toLowerCase();
+                $('#designation-table tbody tr').filter(function () {
+                    $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1);
+                });
+            });
+        });
+    </script>
 @endsection

--- a/resources/views/layouts/partials/alerts.blade.php
+++ b/resources/views/layouts/partials/alerts.blade.php
@@ -1,0 +1,12 @@
+@if(session('success'))
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        {{ session('success') }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+@endif
+@if(session('error'))
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        {{ session('error') }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+@endif

--- a/resources/views/layouts/vertical.blade.php
+++ b/resources/views/layouts/vertical.blade.php
@@ -19,6 +19,8 @@
 
             <div class="container-fluid">
 
+                @include('layouts.partials.alerts')
+
                 @yield('content')
 
             </div>


### PR DESCRIPTION
## Summary
- show flash messages in layout
- add edit modals and live search to designations & departments lists
- enable inline editing using shared modal

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adf12ff3d08326b2d664e1eb9fe1ff