### PR TITLE
Add toast notifications and delete confirmations

### DIFF
--- a/resources/views/dashboard/departments/index.blade.php
+++ b/resources/views/dashboard/departments/index.blade.php
@@ -29,7 +29,7 @@
                                 <td class="text-center">
                                     <div class="d-flex justify-content-center gap-2">
                                         <button type="button" class="btn btn-sm btn-warning" data-bs-toggle="modal" data-bs-target="#departmentModal" data-url="{{ route('departments.update', $department) }}" data-name="{{ $department->name }}">Edit</button>
-                                        <form method="POST" action="{{ route('departments.destroy', $department) }}">
+                                        <form method="POST" action="{{ route('departments.destroy', $department) }}" class="delete-form">
                                             @csrf
                                             @method('DELETE')
                                             <button class="btn btn-sm btn-danger">Delete</button>

--- a/resources/views/dashboard/designations/index.blade.php
+++ b/resources/views/dashboard/designations/index.blade.php
@@ -29,7 +29,7 @@
                                 <td class="text-center">
                                     <div class="d-flex justify-content-center gap-2">
                                         <button type="button" class="btn btn-sm btn-warning" data-bs-toggle="modal" data-bs-target="#designationModal" data-url="{{ route('designations.update', $designation) }}" data-name="{{ $designation->name }}">Edit</button>
-                                        <form method="POST" action="{{ route('designations.destroy', $designation) }}">
+                                        <form method="POST" action="{{ route('designations.destroy', $designation) }}" class="delete-form">
                                             @csrf
                                             @method('DELETE')
                                             <button class="btn btn-sm btn-danger">Delete</button>

--- a/resources/views/layouts/partials/alerts.blade.php
+++ b/resources/views/layouts/partials/alerts.blade.php
@@ -1,12 +1,23 @@
 @if(session('success'))
-    <div class="alert alert-success alert-dismissible fade show" role="alert">
-        {{ session('success') }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            iziToast.success({
+                title: 'Success',
+                message: '{{ session('success') }}',
+                position: 'topRight'
+            });
+        });
+    </script>
 @endif
 @if(session('error'))
-    <div class="alert alert-danger alert-dismissible fade show" role="alert">
-        {{ session('error') }}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            iziToast.error({
+                title: 'Error',
+                message: '{{ session('error') }}',
+                position: 'topRight'
+            });
+        });
+    </script>
 @endif
+

--- a/resources/views/layouts/partials/head-css.blade.php
+++ b/resources/views/layouts/partials/head-css.blade.php
@@ -5,6 +5,8 @@
 
 @yield('css')
 
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/izitoast/dist/css/iziToast.min.css">
+
 @vite([ 'resources/scss/icons.scss', 'resources/scss/style.scss'])
 
 @vite([ 'resources/js/config.js'])

--- a/resources/views/layouts/vertical.blade.php
+++ b/resources/views/layouts/vertical.blade.php
@@ -30,6 +30,27 @@
 
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <script src="https://cdn.jsdelivr.net/npm/izitoast/dist/js/iziToast.min.js"></script>
+    <script>
+        $(document).on('submit', '.delete-form', function (e) {
+            e.preventDefault();
+            const form = this;
+            Swal.fire({
+                title: 'Are you sure?',
+                text: 'This action cannot be undone!',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                cancelButtonColor: '#3085d6',
+                confirmButtonText: 'Yes, delete it!'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    form.submit();
+                }
+            });
+        });
+    </script>
     @include('layouts.partials/vendor-scripts')
 
 </body>


### PR DESCRIPTION
## Summary
- replace bootstrap alerts with IziToast notifications
- include SweetAlert-based confirmation dialog for delete forms
- wire delete forms to new confirmation handler

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token, cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68adf5187164832688eb632c8613ccda