### PR TITLE
Adjust smart card crop and validation dimensions

### DIFF
--- a/app/Http/Requests/StoreSmartCardRequest.php
+++ b/app/Http/Requests/StoreSmartCardRequest.php
@@ -33,8 +33,8 @@ class StoreSmartCardRequest extends FormRequest
             'blood_id'          => 'required',
             'emergency_contact' => ['required','numeric', new Phone(),'unique:nu_smart_cards,emergency_contact'],
             'present_address'   => 'required|string',
-            'image'             => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=810,height=990',
-            'signature'         => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=600,height=160'
+            'image'             => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=531,height=649',
+            'signature'         => 'required|image|mimes:jpeg,png,jpg,webp|max:2048|dimensions:width=300,height=80'
         ];
     }
 }

--- a/app/Http/Requests/updateSmartCardRequest.php
+++ b/app/Http/Requests/updateSmartCardRequest.php
@@ -36,8 +36,8 @@ class updateSmartCardRequest extends FormRequest
             'order_position'    => 'nullable|numeric',
             'emergency_contact' => ['required','numeric',new Phone(), Rule::unique('nu_smart_cards', 'emergency_contact')->ignore($this->nu_smart_card->id)],
             'present_address'   => 'required|string',
-            'image'             => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=810,height=990'],
-            'signature'         => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=600,height=160'],
+            'image'             => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=531,height=649'],
+            'signature'         => ['nullable', 'image', 'mimes:jpeg,png,jpg,webp', 'max:2048', 'dimensions:width=300,height=80'],
         ];
     }
 }

--- a/resources/views/frontend/nuSmartCard/index.blade.php
+++ b/resources/views/frontend/nuSmartCard/index.blade.php
@@ -201,11 +201,11 @@
         }
 
         profileInput.addEventListener("change", function () {
-            handleImageSelection(this, 45 / 55, 810, 990);
+            handleImageSelection(this, 45 / 55, 531, 649);
         });
 
         signatureInput.addEventListener("change", function () {
-            handleImageSelection(this, 300 / 80, 600, 160);
+            handleImageSelection(this, 300 / 80, 300, 80);
         });
 
         document.getElementById("cancelCrop").addEventListener("click", function () {
@@ -216,8 +216,8 @@
 
         document.getElementById("cropImage").addEventListener("click", function () {
             if (cropper) {
-                const width = activeInput === profileInput ? 810 : 600;
-                const height = activeInput === profileInput ? 990 : 160;
+                const width = activeInput === profileInput ? 531 : 300;
+                const height = activeInput === profileInput ? 649 : 80;
                 const canvas = cropper.getCroppedCanvas({
                     width: width,
                     height: height,

--- a/resources/views/nu-smart-card/create.blade.php
+++ b/resources/views/nu-smart-card/create.blade.php
@@ -200,8 +200,8 @@
 
             document.getElementById("cropImage").addEventListener("click", function () {
                 if (cropper) {
-                    let width = activeInput === profileInput ? 810 : 600;
-                    let height = activeInput === profileInput ? 990 : 160;
+                    let width = activeInput === profileInput ? 531 : 300;
+                    let height = activeInput === profileInput ? 649 : 80;
                     const canvas = cropper.getCroppedCanvas({ width: width, height: height });
 
                     canvas.toBlob(blob => {

--- a/resources/views/nu-smart-card/edit.blade.php
+++ b/resources/views/nu-smart-card/edit.blade.php
@@ -208,8 +208,8 @@
 
             document.getElementById("cropImage").addEventListener("click", function () {
                 if (cropper) {
-                    let width = activeInput === profileInput ? 810 : 600;
-                    let height = activeInput === profileInput ? 990 : 160;
+                    let width = activeInput === profileInput ? 531 : 300;
+                    let height = activeInput === profileInput ? 649 : 80;
                     const canvas = cropper.getCroppedCanvas({ width: width, height: height });
 
                     canvas.toBlob(blob => {


### PR DESCRIPTION
## Summary
- enforce 531x649 photo and 300x80 signature dimensions in validation
- crop profile and signature images to the new dimensions across create, edit, and public forms

## Testing
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae052cb3688326a845e6cc29856571