### PR TITLE
Fix PDF single view to show department and designation names

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -240,7 +240,7 @@ class DashboardController extends Controller
     public function getSinglePdfData($id)
     {
         // get single data
-        $data = NuSmartCard::query()->with('blood')->findOrFail($id);
+        $data = NuSmartCard::query()->with(['blood', 'department', 'designation'])->findOrFail($id);
         date_default_timezone_set("Asia/Dhaka");
         $html = '
         <!doctype html>
@@ -302,11 +302,11 @@ class DashboardController extends Controller
                 </tr>
                 <tr>
                     <th>Designation</th>
-                    <td>'.$data->designation.'</td>
+                    <td>'.($data->designation->name ?? '').'</td>
                 </tr>
                 <tr>
                     <th>Department</th>
-                    <td>'.$data->department.'</td>
+                    <td>'.($data->department->name ?? '').'</td>
                 </tr>
                 <tr>
                     <th>PF No</th>

--- a/app/Http/Controllers/NuSmartCardController.php
+++ b/app/Http/Controllers/NuSmartCardController.php
@@ -43,7 +43,7 @@ class NuSmartCardController extends Controller
         }
 
         // Fetch the record from the database
-        $data = NuSmartCard::find($submittedId);
+        $data = NuSmartCard::with(['blood', 'department', 'designation'])->find($submittedId);
 
         if (!$data) {
             return redirect()->route('nu-smart-card.store_data')->with('error', 'Record not found!');

--- a/resources/views/frontend/nuSmartCard/view.blade.php
+++ b/resources/views/frontend/nuSmartCard/view.blade.php
@@ -24,11 +24,11 @@
             </tr>
             <tr class="border-b border-gray-300 dark:border-gray-700">
                 <th class="p-2 w-50">Department:</th>
-                <td class="p-2">{{ $data->department }}</td>
+                <td class="p-2">{{ $data->department?->name }}</td>
             </tr>
             <tr class="border-b border-gray-300 dark:border-gray-700">
                 <th class="p-2 w-50">Designation:</th>
-                <td class="p-2">{{ $data->designation }}</td>
+                <td class="p-2">{{ $data->designation?->name }}</td>
             </tr>
             <tr class="border-b border-gray-300 dark:border-gray-700">
                 <th class="p-2 w-50">PF Number:</th>


### PR DESCRIPTION
## Summary
- Fix single PDF generation to use related department and designation names
- Update frontend view to display related department and designation names
- Ensure smart card view loads required relations

## Testing
- `composer install` *(fails: requires GitHub token)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae008bd6448326a89590513af53e9c