### PR TITLE
Add search and Word export for smart cards

### DIFF
--- a/resources/views/nu-smart-card/index.blade.php
+++ b/resources/views/nu-smart-card/index.blade.php
@@ -7,10 +7,17 @@
 
     <div class="card">
         <div class="card-header">
-            <div class="flex-box justify-content-between">
+            <div class="flex-box justify-content-between align-items-center">
                 <h5 class="card-title">College Inspection Staff List</h5>
-                <a class="btn btn-sm btn-red" target="_blank" href="{{ route('view-pdf') }}">PDF Download</a>
-                <a class="btn btn-sm btn-info" href="{{ route('nu-smart-card.create') }}">Add New</a>
+                <div class="d-flex align-items-center">
+                    <form method="GET" action="{{ route('nu-smart-card.index') }}" class="d-flex me-2">
+                        <input type="text" name="search" value="{{ request('search') }}" class="form-control form-control-sm" placeholder="Search...">
+                        <button class="btn btn-primary btn-sm ms-2" type="submit">Search</button>
+                    </form>
+                    <a class="btn btn-sm btn-success me-2" href="{{ route('export-word') }}">Word Export</a>
+                    <a class="btn btn-sm btn-red me-2" target="_blank" href="{{ route('view-pdf') }}">PDF Download</a>
+                    <a class="btn btn-sm btn-info" href="{{ route('nu-smart-card.create') }}">Add New</a>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- allow searching smart card records by name or PF number
- add .docx export for smart card data
- expose search box and Word export button on smart card list page

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1287b2e483268a9e4085fbb4e2a7