### PR TITLE
Add live smart card search

### DIFF
--- a/app/Http/Controllers/NuSmartCardController.php
+++ b/app/Http/Controllers/NuSmartCardController.php
@@ -125,11 +125,16 @@ class NuSmartCardController extends Controller
     public function search(Request $request): JsonResponse
     {
         $term = $request->get('q');
-        $results = NuSmartCard::with(["department", "designation"])
-            ->where("name", "like", "%" . $term . "%")
-            ->orWhere("pf_number", "like", "%" . $term . "%")
+
+        $results = NuSmartCard::with(['department', 'designation'])
+            ->where(function ($query) use ($term) {
+                $query->where('name', 'like', "%{$term}%")
+                      ->orWhere('pf_number', 'like', "%{$term}%")
+                      ->orWhere('id_card_number', 'like', "%{$term}%");
+            })
             ->limit(10)
             ->get();
+
         return response()->json($results);
     }
 }

--- a/resources/views/frontend/nuSmartCard/index.blade.php
+++ b/resources/views/frontend/nuSmartCard/index.blade.php
@@ -152,11 +152,17 @@
         let croppedProfileBlob = null;
         let croppedSignatureBlob = null;
 
-        $('#live-search').on('keyup', function(){
-            let q = $(this).val();
-            if(q.length < 2){ $('#search-results').empty(); return; }
-            $.get('/nu-smart-card/search', {q:q}, function(data){
-                let html = data.map(item => `<li>${item.name} - ${(item.designation ? item.designation.name : '')}</li>`).join('');
+        $('#live-search').on('keyup', function () {
+            const q = $(this).val();
+            if (q.length < 2) {
+                $('#search-results').empty();
+                return;
+            }
+
+            $.get('/nu-smart-card/search', { q: q }, function (data) {
+                const html = data.length
+                    ? data.map(item => `<li>${item.name} - ${item.pf_number || ''} - ${item.id_card_number || ''}</li>`).join('')
+                    : '<li class="text-gray-500">No results found</li>';
                 $('#search-results').html(html);
             });
         });


### PR DESCRIPTION
## Summary
- expand smart card search API to match name, PF number, and ID card number
- implement frontend live search UI that displays PF and ID numbers and shows no-results message

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae15704e508326a6c083924f60218d