### PR TITLE
Fix live search route for Nu Smart Card

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -27,8 +27,8 @@ Route::group(['prefix' => '/dashboard', 'middleware' => 'auth'], function () {
     // profile
     Route::resource('profile', ProfileController::class);
 
-    Route::resource('nu-smart-card', DashboardController::class);
     Route::get('nu-smart-card/live-search', [DashboardController::class, 'liveSearch'])->name('nu-smart-card.live-search');
+    Route::resource('nu-smart-card', DashboardController::class);
     Route::get('view-pdf', [DashboardController::class, 'getPdfData'])->name('view-pdf');
     Route::get('single-pdf/{id}', [DashboardController::class, 'getSinglePdfData'])->name('single-pdf');
     Route::get('export-word', [DashboardController::class, 'exportWord'])->name('export-word');


### PR DESCRIPTION
## Summary
- Ensure Nu Smart Card live-search route is defined before the resource routes to avoid being swallowed by `nu-smart-card/{id}`

## Testing
- `php artisan test` *(fails: Failed to open required 'vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1b897a9883268995df84ac0ec008