### PR TITLE
Handle null values in exportWord cell helper

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -121,7 +121,7 @@ class DashboardController extends Controller
     {
         $data = NuSmartCard::with(['designation', 'department', 'blood'])->orderBy('order_position', 'asc')->get();
 
-        $cell = fn(string $value): string => '<w:tc><w:p><w:r><w:t>' . htmlspecialchars($value) . '</w:t></w:r></w:p></w:tc>';
+        $cell = fn(?string $value): string => '<w:tc><w:p><w:r><w:t>' . htmlspecialchars($value ?? '') . '</w:t></w:r></w:p></w:tc>';
 
         $rowsXml = '';
         $relsXmlEntries = '';


### PR DESCRIPTION
## Summary
- allow nullable strings in exportWord's cell helper to prevent errors when data fields are null

## Testing
- `php artisan test` *(fails: vendor/autoload.php not found)*
- `composer install --no-interaction --no-progress` *(fails: failed to clone https://github.com/doctrine/inflector.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1d1ab8688326aac2ef64ae709b24