### PR TITLE
Ensure uploaded images saved in public path

### DIFF
--- a/app/Models/NuSmartCard.php
+++ b/app/Models/NuSmartCard.php
@@ -86,8 +86,18 @@ class NuSmartCard extends Model
         }
         // Generate new image/file name
         $extension = $file->getClientOriginalExtension();
-        $fileName = time() . '_' . Str::slug(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME)).'.'.$extension;
-        $file->move($uploadPath, $fileName); // Move file to destination
+        $fileName = time() . '_' . Str::slug(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME)) . '.' . $extension;
+
+        // Determine the absolute destination path inside the public directory
+        $destination = public_path($uploadPath);
+
+        // Ensure the destination directory exists before moving the file
+        if (!File::exists($destination)) {
+            File::makeDirectory($destination, 0755, true);
+        }
+
+        $file->move($destination, $fileName); // Move file to destination
+
         return $fileName;
     }
 


### PR DESCRIPTION
## Summary
- save uploaded images and signatures under Laravel's public directory
- create destination directory when missing so DOCX export can embed images

## Testing
- `composer install` *(fails: CONNECT tunnel failed / requires GitHub token)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e5b57348326ba31e890394618a3