### PR TITLE
Ensure images and signatures appear in Word export

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -228,7 +228,10 @@ class DashboardController extends Controller
         $zip->addFromString('word/document.xml', $documentXml);
         $zip->addFromString('word/_rels/document.xml.rels', $documentRelsXml);
         foreach ($imageFiles as $img) {
-            $zip->addFile($img['path'], $img['name']);
+            // Use addFromString to ensure the image binary is properly added to the archive
+            if (is_readable($img['path'])) {
+                $zip->addFromString($img['name'], file_get_contents($img['path']));
+            }
         }
         $zip->close();
 


### PR DESCRIPTION
## Summary
- Add binary embedding of images when generating Word document

## Testing
- `php -l app/Http/Controllers/DashboardController.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae204ace748326845dd49ee7bac76a