### PR TITLE
fix null property access in dashboard export

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -315,11 +315,11 @@ class DashboardController extends Controller
             $html .= '<tr>';
             $html .= '<td>'.++$i.'</td>';
             $html .= '<td>'.$row['name'].'</td>';
-            $html .= '<td>'.($row->designation->name ?? '').'</td>';
-            $html .= '<td>'.($row->department->name ?? '').'</td>';
+            $html .= '<td>'.($row->designation?->name ?? '').'</td>';
+            $html .= '<td>'.($row->department?->name ?? '').'</td>';
             $html .= '<td>'.$row['pf_number'].'</td>';
             $html .= '<td>'. \App\Helpers\DateHelpers::dateFormat($row['prl_date'], 'd/m/Y').'</td>';
-            $html .= '<td>'.$row->blood->name.'</td>';
+            $html .= '<td>'.($row->blood?->name ?? '').'</td>';
             $html .= '<td>'.$row['mobile_number'].'</td>';
             $html .= '<td>'.$row['present_address'].'</td>';
             $html .= '<td>'.$row['emergency_contact'].'</td>';


### PR DESCRIPTION
## Summary
- guard designation, department, and blood accesses with PHP nullsafe operator to avoid runtime errors when any relation is missing

## Testing
- `php artisan test` *(fails: Failed opening required vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68ae220e41d88326b967081af5aecca8