### PR TITLE
Add Nu Smart Card data API endpoint

### DIFF
--- a/app/Http/Controllers/Api/NuSmartCardController.php
+++ b/app/Http/Controllers/Api/NuSmartCardController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\NuSmartCard;
+use Illuminate\Http\JsonResponse;
+
+class NuSmartCardController extends Controller
+{
+    /**
+     * Return all Nu Smart Card records with related data.
+     */
+    public function index(): JsonResponse
+    {
+        $cards = NuSmartCard::with(['blood', 'department', 'designation'])
+            ->orderBy('order_position', 'asc')
+            ->get();
+
+        return response()->json($cards);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\NuSmartCardController;
+
+Route::get('/nu-smart-cards', [NuSmartCardController::class, 'index']);


### PR DESCRIPTION
## Summary
- add API controller returning Nu Smart Card records with related details
- expose `/api/nu-smart-cards` route

## Testing
- `php artisan test` *(fails: require vendor/autoload.php - missing dependencies)*
- `composer install` *(fails: CONNECT tunnel failed 403 to api.github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68af1e8ad554832691054dbf19e230ac