### PR TITLE
Fetch registrar signature from database

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -8,6 +8,7 @@ use App\Models\BloodGroup;
 use App\Models\NuSmartCard;
 use App\Models\Department;
 use App\Models\Designation;
+use App\Models\IdCardSetting;
 use App\Helpers\DateHelpers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -69,7 +70,8 @@ class DashboardController extends Controller
     public function card($id)
     {
         $nuSmartCard = NuSmartCard::with(['designation', 'department', 'blood'])->findOrFail($id);
-        return view('nu-smart-card.card', compact('nuSmartCard'));
+        $idCardSettings = IdCardSetting::first();
+        return view('nu-smart-card.card', compact('nuSmartCard', 'idCardSettings'));
     }
 
     public function edit($id)

--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -175,8 +175,10 @@
       <img src="https://api.qrserver.com/v1/create-qr-code/?size=50x50&data={{ urlencode($nuSmartCard->id_card_number) }}" alt="QR" class="qr">
 
       <div class="sig">
-        <img src="{{ asset('images/logo-sm.png') }}" alt="Registrar" class="sig-img">
-        <div>Registrar</div>
+        @if($idCardSettings?->authority_logo)
+          <img src="{{ asset('storage/' . $idCardSettings->authority_logo) }}" alt="{{ $idCardSettings->authority_name ?? 'Registrar' }}" class="sig-img">
+        @endif
+        <div>{{ $idCardSettings->authority_name ?? 'Registrar' }}</div>
       </div>
     </div>
     </div>


### PR DESCRIPTION
## Summary
- load ID card settings in Dashboard controller to retrieve registrar signature
- render registrar signature from stored ID card settings on ID card view

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68af607ef0488326a7153dc816854928