### PR TITLE
Enhance ID card customization with multilingual support

### DIFF
--- a/app/Http/Controllers/IdCardSettingController.php
+++ b/app/Http/Controllers/IdCardSettingController.php
@@ -25,17 +25,22 @@ class IdCardSettingController extends Controller
     {
         $settings = IdCardSetting::first() ?? new IdCardSetting();
 
-        $settings->organization_name = $request->organization_name;
-        $settings->authority_name    = $request->authority_name;
+        $settings->organization_name           = $request->organization_name;
+        $settings->organization_name_en        = $request->organization_name_en;
+        $settings->organization_name_font_size = $request->organization_name_font_size;
+        $settings->organization_logo_width     = $request->organization_logo_width;
+        $settings->organization_logo_height    = $request->organization_logo_height;
+        $settings->authority_name              = $request->authority_name;
+        $settings->back_footer                 = $request->back_footer;
 
         if ($request->hasFile('organization_logo')) {
             $path = $request->organization_logo->store('logos', 'public');
             $settings->organization_logo = $path;
         }
 
-        if ($request->hasFile('authority_logo')) {
-            $path = $request->authority_logo->store('logos', 'public');
-            $settings->authority_logo = $path;
+        if ($request->hasFile('authority_signature')) {
+            $path = $request->authority_signature->store('signatures', 'public');
+            $settings->authority_signature = $path;
         }
 
         $settings->save();

--- a/app/Models/IdCardSetting.php
+++ b/app/Models/IdCardSetting.php
@@ -8,9 +8,14 @@ class IdCardSetting extends Model
 {
     protected $fillable = [
         'organization_name',
+        'organization_name_en',
+        'organization_name_font_size',
         'organization_logo',
+        'organization_logo_width',
+        'organization_logo_height',
         'authority_name',
-        'authority_logo',
+        'authority_signature',
+        'back_footer',
     ];
 }
 

--- a/database/migrations/2025_09_05_000004_add_fields_to_id_card_settings_table.php
+++ b/database/migrations/2025_09_05_000004_add_fields_to_id_card_settings_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('id_card_settings', function (Blueprint $table) {
+            $table->string('organization_name_en')->nullable();
+            $table->unsignedInteger('organization_name_font_size')->nullable();
+            $table->unsignedInteger('organization_logo_width')->nullable();
+            $table->unsignedInteger('organization_logo_height')->nullable();
+            $table->string('authority_signature')->nullable();
+            $table->text('back_footer')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('id_card_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'organization_name_en',
+                'organization_name_font_size',
+                'organization_logo_width',
+                'organization_logo_height',
+                'authority_signature',
+                'back_footer',
+            ]);
+        });
+    }
+};

--- a/resources/views/dashboard/id-card/settings.blade.php
+++ b/resources/views/dashboard/id-card/settings.blade.php
@@ -8,8 +8,16 @@
             <form action="{{ route('id-card.settings.update') }}" method="POST" enctype="multipart/form-data">
                 @csrf
                 <div class="mb-3">
-                    <label class="form-label">প্রতিষ্ঠানের নাম</label>
+                    <label class="form-label">প্রতিষ্ঠানের নাম (বাংলা)</label>
                     <input type="text" name="organization_name" class="form-control" value="{{ $settings->organization_name }}">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">প্রতিষ্ঠানের নাম (ইংরেজি)</label>
+                    <input type="text" name="organization_name_en" class="form-control" value="{{ $settings->organization_name_en }}">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">বাংলা নামের ফন্ট সাইজ</label>
+                    <input type="number" name="organization_name_font_size" class="form-control" value="{{ $settings->organization_name_font_size }}">
                 </div>
                 <div class="mb-3">
                     <label class="form-label">প্রতিষ্ঠানের লোগো</label>
@@ -18,16 +26,30 @@
                         <img src="{{ asset('storage/' . $settings->organization_logo) }}" height="60" class="mt-2">
                     @endif
                 </div>
+                <div class="mb-3 row">
+                    <div class="col">
+                        <label class="form-label">লোগোর প্রস্থ (px)</label>
+                        <input type="number" name="organization_logo_width" class="form-control" value="{{ $settings->organization_logo_width }}">
+                    </div>
+                    <div class="col">
+                        <label class="form-label">লোগোর উচ্চতা (px)</label>
+                        <input type="number" name="organization_logo_height" class="form-control" value="{{ $settings->organization_logo_height }}">
+                    </div>
+                </div>
                 <div class="mb-3">
                     <label class="form-label">কর্তৃপক্ষের নাম</label>
                     <input type="text" name="authority_name" class="form-control" value="{{ $settings->authority_name }}">
                 </div>
                 <div class="mb-3">
-                    <label class="form-label">কর্তৃপক্ষের লোগো</label>
-                    <input type="file" name="authority_logo" class="form-control">
-                    @if($settings->authority_logo)
-                        <img src="{{ asset('storage/' . $settings->authority_logo) }}" height="60" class="mt-2">
+                    <label class="form-label">কর্তৃপক্ষের স্বাক্ষর</label>
+                    <input type="file" name="authority_signature" class="form-control">
+                    @if($settings->authority_signature)
+                        <img src="{{ asset('storage/' . $settings->authority_signature) }}" height="60" class="mt-2">
                     @endif
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">ব্যাক সাইড ফুটার</label>
+                    <textarea name="back_footer" class="form-control" rows="3">{{ $settings->back_footer }}</textarea>
                 </div>
                 <button type="submit" class="btn btn-primary">সংরক্ষণ</button>
             </form>

--- a/resources/views/id_card/show.blade.php
+++ b/resources/views/id_card/show.blade.php
@@ -1,15 +1,18 @@
 <div class="id-card">
     @if($settings?->organization_logo)
-        <img src="{{ asset('storage/' . $settings->organization_logo) }}" class="org-logo">
+        <img src="{{ asset('storage/' . $settings->organization_logo) }}" class="org-logo" style="width: {{ $settings->organization_logo_width ?? 28 }}px; height: {{ $settings->organization_logo_height ?? 28 }}px;">
     @endif
 
-    <h2>{{ $settings?->organization_name }}</h2>
+    <h2 style="font-size: {{ $settings->organization_name_font_size ?? 16 }}px;">{{ $settings?->organization_name }}</h2>
+    @if($settings?->organization_name_en)
+        <h3>{{ $settings->organization_name_en }}</h3>
+    @endif
     <h3>{{ $user->name }}</h3>
 
     <img src="data:image/png;base64,{{ base64_encode($qrCode) }}" class="qr-code">
 
-    @if($settings?->authority_logo)
-        <img src="{{ asset('storage/' . $settings->authority_logo) }}" class="authority-logo">
+    @if($settings?->authority_signature)
+        <img src="{{ asset('storage/' . $settings->authority_signature) }}" class="authority-logo">
     @endif
 </div>
 

--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -49,8 +49,6 @@
       border-bottom:1px solid var(--border);
     }
     .logo {
-      width: 28px;
-      height: 28px;
       border-radius: 6px;
       overflow: hidden;
       flex-shrink: 0;
@@ -64,7 +62,6 @@
     }
     .org{line-height:1.05;}
     .org .bn {
-      font-size: 13px;
       font-weight: 700;
     }
     .org .en {
@@ -148,12 +145,14 @@
     <!-- FRONT -->
     <div class="card">
       <div class="front-header">
-        <div class="logo">
-          <img src="https://upload.wikimedia.org/wikipedia/en/thumb/5/58/National_University%2C_Bangladesh_crest.svg/1200px-National_University%2C_Bangladesh_crest.svg.png" alt="NU Logo">
+        <div class="logo" style="width: {{ $idCardSettings->organization_logo_width ?? 28 }}px; height: {{ $idCardSettings->organization_logo_height ?? 28 }}px;">
+          @if($idCardSettings?->organization_logo)
+            <img src="{{ asset('storage/' . $idCardSettings->organization_logo) }}" alt="{{ $idCardSettings->organization_name_en ?? $idCardSettings->organization_name }}">
+          @endif
         </div>
         <div class="org">
-          <div class="bn">জাতীয় বিশ্ববিদ্যালয়</div>
-          <div class="en">National University Bangladesh</div>
+          <div class="bn" style="font-size: {{ $idCardSettings->organization_name_font_size ?? 13 }}px;">{{ $idCardSettings->organization_name }}</div>
+          <div class="en">{{ $idCardSettings->organization_name_en }}</div>
         </div>
       </div>
       <div class="front-body">
@@ -175,8 +174,8 @@
       <img src="https://api.qrserver.com/v1/create-qr-code/?size=50x50&data={{ urlencode($nuSmartCard->id_card_number) }}" alt="QR" class="qr">
 
       <div class="sig">
-        @if($idCardSettings?->authority_logo)
-          <img src="{{ asset('storage/' . $idCardSettings->authority_logo) }}" alt="{{ $idCardSettings->authority_name ?? 'Registrar' }}" class="sig-img">
+        @if($idCardSettings?->authority_signature)
+          <img src="{{ asset('storage/' . $idCardSettings->authority_signature) }}" alt="{{ $idCardSettings->authority_name ?? 'Registrar' }}" class="sig-img">
         @endif
         <div>{{ $idCardSettings->authority_name ?? 'Registrar' }}</div>
       </div>
@@ -185,12 +184,14 @@
     <!-- BACK -->
     <div class="card">
       <div class="front-header">
-        <div class="logo">
-          <img src="https://upload.wikimedia.org/wikipedia/en/thumb/5/58/National_University%2C_Bangladesh_crest.svg/1200px-National_University%2C_Bangladesh_crest.svg.png" alt="NU Logo">
+        <div class="logo" style="width: {{ $idCardSettings->organization_logo_width ?? 28 }}px; height: {{ $idCardSettings->organization_logo_height ?? 28 }}px;">
+          @if($idCardSettings?->organization_logo)
+            <img src="{{ asset('storage/' . $idCardSettings->organization_logo) }}" alt="{{ $idCardSettings->organization_name_en ?? $idCardSettings->organization_name }}">
+          @endif
         </div>
         <div class="org">
-          <div class="bn">জাতীয় বিশ্ববিদ্যালয়</div>
-          <div class="en">National University Bangladesh</div>
+          <div class="bn" style="font-size: {{ $idCardSettings->organization_name_font_size ?? 13 }}px;">{{ $idCardSettings->organization_name }}</div>
+          <div class="en">{{ $idCardSettings->organization_name_en }}</div>
         </div>
       </div>
       <div class="back-body">
@@ -200,7 +201,7 @@
         <div class="kv"><div class="k">Address</div><div>: {{ $nuSmartCard->present_address }}</div></div>
         <div class="kv push-down"><div class="k">Emergency Contact</div><div>: {{ $nuSmartCard->emergency_contact }}</div></div>
         <div class="kv"><div class="k">Valid Up to</div><div>: {{ \App\Helpers\DateHelpers::dateFormat($nuSmartCard->prl_date, 'd-m-Y') }}</div></div>
-        <div class="note">If found, please return to the Registrar, National University, Gazipur-1704, Bangladesh</div>
+        <div class="note">{{ $idCardSettings->back_footer }}</div>
       </div>
       <div class="barcode">{{ $nuSmartCard->id_card_number }}</div>
     </div>


### PR DESCRIPTION
## Summary
- allow English organization names, configurable font sizes, logo dimensions, authority signature, and back-side footer via ID card settings
- render ID cards using the new settings including dynamic organization info, signature in place of logo, and database-driven footer
- migrate database to store new settings fields

## Testing
- `composer install` *(fails: requires GitHub token)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af6c17a08c83268d0e15114c7c0bc8