### PR TITLE
feat: make ID photo background configurable

### DIFF
--- a/app/Http/Controllers/IdCardSettingController.php
+++ b/app/Http/Controllers/IdCardSettingController.php
@@ -32,6 +32,7 @@ class IdCardSettingController extends Controller
         $settings->organization_logo_height    = $request->organization_logo_height;
         $settings->authority_name              = $request->authority_name;
         $settings->back_footer                 = $request->back_footer;
+        $settings->photo_background_color      = $request->photo_background_color;
 
         if ($request->hasFile('organization_logo')) {
             $path = $request->organization_logo->store('logos', 'public');

--- a/app/Models/IdCardSetting.php
+++ b/app/Models/IdCardSetting.php
@@ -16,6 +16,7 @@ class IdCardSetting extends Model
         'authority_name',
         'authority_signature',
         'back_footer',
+        'photo_background_color',
     ];
 }
 

--- a/database/migrations/2025_09_05_000005_add_photo_background_color_to_id_card_settings_table.php
+++ b/database/migrations/2025_09_05_000005_add_photo_background_color_to_id_card_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('id_card_settings', function (Blueprint $table) {
+            $table->string('photo_background_color')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('id_card_settings', function (Blueprint $table) {
+            $table->dropColumn('photo_background_color');
+        });
+    }
+};

--- a/resources/views/dashboard/id-card/settings.blade.php
+++ b/resources/views/dashboard/id-card/settings.blade.php
@@ -48,6 +48,10 @@
                     @endif
                 </div>
                 <div class="mb-3">
+                    <label class="form-label">ছবির ব্যাকগ্রাউন্ড রঙ</label>
+                    <input type="color" name="photo_background_color" class="form-control form-control-color" value="{{ $settings->photo_background_color ?? '#f3f4f6' }}">
+                </div>
+                <div class="mb-3">
                     <label class="form-label">ব্যাক সাইড ফুটার</label>
                     <textarea name="back_footer" class="form-control" rows="3">{{ $settings->back_footer }}</textarea>
                 </div>

--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -83,7 +83,7 @@
     }
     .photo{
       width:2.45cm;height:2.75cm;border:1px solid var(--border);border-radius:8px;
-      display:grid;place-items:center;background:#f3f4f6;
+      display:grid;place-items:center;background: {{ $idCardSettings->photo_background_color ?? '#f3f4f6' }};
       margin-bottom:8px;font-size:10px;color:var(--muted);
       overflow:hidden;
     }


### PR DESCRIPTION
## Summary
- allow setting id photo background color in id card settings
- render user photo with configurable background color on card
- store new option via migration and model/controller updates

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: GitHub authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68af7221da3883268d71d7833c13e3a0