### PR TITLE
Ensure photo wrapper background color applied across image

### DIFF
--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -92,7 +92,12 @@
       display:grid;
       place-items:center;
     }
-    .photo-wrapper img{width:100%;height:100%;object-fit:cover;}
+    .photo-wrapper img{
+      width:100%;
+      height:100%;
+      object-fit:cover;
+      background-color:inherit;
+    }
     .meta{text-align:center;}
     .meta h2{margin:4px 0;font-size:14px;font-weight:800;}
     .meta .role{font-size:11px;color:var(--muted);}


### PR DESCRIPTION
## Summary
- Let `.photo-wrapper img` inherit the wrapper's background color so the color fills the full photo area

## Testing
- `php artisan test` *(fails: Failed to open required vendor/autoload.php)*
- `composer install` *(fails: GitHub API 403 requiring token)*

------
https://chatgpt.com/codex/tasks/task_e_68af7b8ee9248326b3e1d356ce4ad80a