### PR TITLE
Remove top padding from front body section

### DIFF
--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -76,6 +76,7 @@
     /* Front body */
     .front-body{
       padding:10px;
+      padding-top:0px;
       display:flex;
       flex-direction:column;
       align-items:center;


### PR DESCRIPTION
## Summary
- Avoid extra whitespace by removing top padding from the card front body

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*


------
https://chatgpt.com/codex/tasks/task_e_68af7c2c636c8326a4ce45acc62a712e