### PR TITLE
Add configurable photo dimensions for ID cards

### DIFF
--- a/app/Http/Controllers/IdCardSettingController.php
+++ b/app/Http/Controllers/IdCardSettingController.php
@@ -33,6 +33,8 @@ class IdCardSettingController extends Controller
         $settings->authority_name              = $request->authority_name;
         $settings->back_footer                 = $request->back_footer;
         $settings->photo_background_color      = $request->photo_background_color;
+        $settings->photo_width                 = $request->photo_width;
+        $settings->photo_height                = $request->photo_height;
 
         if ($request->hasFile('organization_logo')) {
             $path = $request->organization_logo->store('logos', 'public');

--- a/app/Models/IdCardSetting.php
+++ b/app/Models/IdCardSetting.php
@@ -17,6 +17,8 @@ class IdCardSetting extends Model
         'authority_signature',
         'back_footer',
         'photo_background_color',
+        'photo_width',
+        'photo_height',
     ];
 }
 

--- a/database/migrations/2025_09_05_000006_add_photo_dimensions_to_id_card_settings_table.php
+++ b/database/migrations/2025_09_05_000006_add_photo_dimensions_to_id_card_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('id_card_settings', function (Blueprint $table) {
+            $table->decimal('photo_width', 5, 2)->nullable();
+            $table->decimal('photo_height', 5, 2)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('id_card_settings', function (Blueprint $table) {
+            $table->dropColumn(['photo_width', 'photo_height']);
+        });
+    }
+};

--- a/resources/views/dashboard/id-card/settings.blade.php
+++ b/resources/views/dashboard/id-card/settings.blade.php
@@ -51,6 +51,16 @@
                     <label class="form-label">ছবির ব্যাকগ্রাউন্ড রঙ</label>
                     <input type="color" name="photo_background_color" class="form-control form-control-color" value="{{ $settings->photo_background_color ?? '#f3f4f6' }}">
                 </div>
+                <div class="mb-3 row">
+                    <div class="col">
+                        <label class="form-label">ছবির প্রস্থ (cm)</label>
+                        <input type="number" step="0.1" name="photo_width" class="form-control" value="{{ $settings->photo_width }}">
+                    </div>
+                    <div class="col">
+                        <label class="form-label">ছবির উচ্চতা (cm)</label>
+                        <input type="number" step="0.1" name="photo_height" class="form-control" value="{{ $settings->photo_height }}">
+                    </div>
+                </div>
                 <div class="mb-3">
                     <label class="form-label">ব্যাক সাইড ফুটার</label>
                     <textarea name="back_footer" class="form-control" rows="3">{{ $settings->back_footer }}</textarea>

--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -83,7 +83,7 @@
       flex:1;
     }
     .photo-wrapper{
-      width:2.5cm;height:2.8cm;
+      width:{{ $idCardSettings->photo_width ?? 2.5 }}cm;height:{{ $idCardSettings->photo_height ?? 2.8 }}cm;
       border:1px solid var(--border);
       border-radius:8px;
       overflow:hidden;


### PR DESCRIPTION
## Summary
- allow photo width and height to be stored in ID card settings
- expose photo width/height fields in dashboard settings form
- apply configured photo dimensions when rendering smart card
- add migration for photo dimension fields

## Testing
- `npm test` (fails: Missing script "test")
- `php artisan test` (fails: Failed opening required 'vendor/autoload.php')

------
https://chatgpt.com/codex/tasks/task_e_68af80f8ffbc8326a90ad4703afd1d69