### PR TITLE
Add mass ID card PDF download

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -533,4 +533,23 @@ class DashboardController extends Controller
         $mpdf->Output(Str::slug($data->name).'.pdf','I');
     }
 
+    public function downloadAllMastercard()
+    {
+        $nuSmartCards = NuSmartCard::with(['designation','department','blood'])->orderBy('order_position','asc')->get();
+        $idCardSettings = IdCardSetting::first();
+        $html = view('nu-smart-card.all_mastercard_pdf', compact('nuSmartCards','idCardSettings'))->render();
+        $mpdf = new \Mpdf\Mpdf([
+            'default_font' => 'nikosh',
+            'mode' => 'utf-8',
+            'margin_left' => 5,
+            'margin_right' => 5,
+            'margin_top' => 5,
+            'margin_bottom' => 5,
+            'format' => 'Legal',
+            'orientation' => 'L',
+        ]);
+        $mpdf->WriteHTML($html);
+        return $mpdf->Output('all-id-cards.pdf','D');
+    }
+
 }

--- a/resources/views/nu-smart-card/all_mastercard_pdf.blade.php
+++ b/resources/views/nu-smart-card/all_mastercard_pdf.blade.php
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="bn">
+<head>
+    <meta charset="utf-8" />
+    <title>All ID Cards</title>
+    <style>
+        @page { size: Legal; margin: 1cm; }
+        :root{
+            --nu-green:#2f7d32;
+            --nu-blue:#2c7fb8;
+            --text:#111827;
+            --muted:#4b5563;
+            --border:#e5e7eb;
+        }
+        *{ box-sizing:border-box; }
+        .sheets{display:flex;flex-wrap:wrap;gap:20px;}
+        .back-body {
+            padding: 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            font-size: 11px;
+            flex: 1;
+            padding-left: 30px !important;
+        }
+        .sheet{
+            display:grid;
+            grid-template-columns: 5.5cm 5.5cm;
+            gap: 20px;
+        }
+        .card{
+            width:5.5cm;
+            height:8.5cm;
+            background:#fff;
+            border-radius:14px;
+            border:1px solid var(--border);
+            box-shadow: 0 6px 18px rgba(0,0,0,.08);
+            overflow:hidden;
+            position:relative;
+            display:flex;
+            flex-direction:column;
+        }
+        .front-header{
+            display:flex;
+            align-items:center;
+            gap:10px;
+            padding:6px 10px;
+            border-bottom:1px solid var(--border);
+        }
+        .logo {
+            border-radius: 6px;
+            overflow: hidden;
+            flex-shrink: 0;
+            border: 1px solid #eee;
+            padding: 2px;
+        }
+        .logo img{
+            width:100%;
+            height:100%;
+            object-fit:contain;
+        }
+        .org{line-height:1.05;}
+        .org .bn {
+            font-weight: 700;
+        }
+        .org .en {
+            font-size: 9px;
+            color: var(--muted);
+            letter-spacing: 0.2px;
+        }
+        .push-down {
+            margin-top: 14px;
+        }
+        .front-body{
+            padding:10px;
+            padding-top:5px;
+            display:flex;
+            flex-direction:column;
+            align-items:center;
+            flex:1;
+        }
+        .photo-wrapper {
+            width: 100%;
+            height: {{ $idCardSettings->photo_width ?? 100 }}px;
+            background-color: {{ $idCardSettings->photo_background_color ?? '#f3f4f6' }};
+            border-bottom: 1px solid var(--border);
+            overflow: hidden;
+            box-shadow: 0 2px 6px rgba(0,0,0,.1);
+        }
+        .photo-wrapper img {
+            width: 50%;
+            height: {{ $idCardSettings->photo_height ?? 3.5 }}cm;
+            object-fit: contain;
+            border-bottom: 1px solid var(--border);
+            transform: translate(50%);
+        }
+        .meta{text-align:center;}
+        .meta h2{margin:4px 0;font-size:14px;font-weight:800;}
+        .meta .role{font-size:11px;color:var(--muted);}
+        .meta .dept{font-size:11px;}
+        .footer{
+            border-top:1px dashed var(--border);
+            padding:6px 8px;
+            display:flex;
+            justify-content:space-between;
+            align-items:center;
+            margin-top:auto;
+        }
+        .qr{
+            width:50px;
+            height:50px;
+            object-fit:contain;
+            border:1px solid var(--border);
+            border-radius:4px;
+        }
+        .signs{
+            display:flex;
+            justify-content:space-between;
+            gap:20px;
+            flex:1;
+            margin-left:10px;
+        }
+        .sig{text-align:center;font-size:10px;color:var(--muted);}
+        .sig-img{width:70px;height:auto;object-fit:contain;}
+        .kv{display:grid;grid-template-columns:2.2cm 1fr;gap:4px;}
+        .kv .k{color:var(--muted);}
+        .barcode{
+            font-family:monospace;letter-spacing:2px;color:#111;opacity:.7;font-size:12px;
+            writing-mode:vertical-rl;transform:rotate(180deg);position:absolute;left:8px;top:30%;
+        }
+        .note {
+            font-size: 10px;
+            border-top: 1px dashed var(--border);
+            padding: 6px;
+            margin-top: auto;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div class="sheets">
+    @foreach($nuSmartCards as $nuSmartCard)
+        @include('nu-smart-card.partials.id-card', ['nuSmartCard' => $nuSmartCard, 'idCardSettings' => $idCardSettings])
+    @endforeach
+</div>
+</body>
+</html>

--- a/resources/views/nu-smart-card/index.blade.php
+++ b/resources/views/nu-smart-card/index.blade.php
@@ -13,6 +13,7 @@
                     <input type="text" id="search" class="form-control form-control-sm me-2" placeholder="Search...">
                     <a class="btn btn-sm btn-success me-2" href="{{ route('export-word') }}">Word Export</a>
                     <a class="btn btn-sm btn-red me-2" target="_blank" href="{{ route('view-pdf') }}">PDF Download</a>
+                    <a class="btn btn-sm btn-red me-2" target="_blank" href="{{ route('nu-smart-card.all-mastercard') }}">All Mastercard Download</a>
                     <a class="btn btn-sm btn-info" href="{{ route('nu-smart-card.create') }}">Add New</a>
                 </div>
             </div>

--- a/resources/views/nu-smart-card/partials/id-card.blade.php
+++ b/resources/views/nu-smart-card/partials/id-card.blade.php
@@ -1,0 +1,63 @@
+<div class="sheet">
+    <!-- FRONT -->
+    <div class="card">
+        <div class="front-header">
+            <div class="logo" style="width: {{ $idCardSettings->organization_logo_width ?? 28 }}px; height: {{ $idCardSettings->organization_logo_height ?? 28 }}px;">
+                @if($idCardSettings?->organization_logo)
+                    <img src="{{ asset('storage/' . $idCardSettings->organization_logo) }}" alt="{{ $idCardSettings->organization_name_en ?? $idCardSettings->organization_name }}">
+                @endif
+            </div>
+            <div class="org">
+                <div class="bn" style="font-size: {{ $idCardSettings->organization_name_font_size ?? 13 }}px;">{{ $idCardSettings->organization_name }}</div>
+                <div class="en">{{ $idCardSettings->organization_name_en }}</div>
+            </div>
+        </div>
+        <div class="photo-wrapper">
+            <img src="{{ asset('uploads/images/' . $nuSmartCard->image) }}" alt="{{ $nuSmartCard->name }}">
+        </div>
+        <div class="front-body">
+            <div class="meta">
+                <h2>{{ $nuSmartCard->name }}</h2>
+                <div class="role">{{ $nuSmartCard->designation?->name }}</div>
+                <div class="dept">{{ $nuSmartCard->department?->name }}</div>
+            </div>
+        </div>
+        <div class="footer">
+            <div class="sig">
+                <img src="{{ asset('uploads/signature/' . $nuSmartCard->signature) }}" alt="Card Holder" class="sig-img">
+                <div>Card Holder</div>
+            </div>
+            <img src="https://api.qrserver.com/v1/create-qr-code/?size=50x50&data={{ urlencode($nuSmartCard->id_card_number) }}" alt="QR" class="qr">
+            <div class="sig">
+                @if($idCardSettings?->authority_signature)
+                    <img src="{{ asset('storage/' . $idCardSettings->authority_signature) }}" alt="{{ $idCardSettings->authority_name ?? 'Registrar' }}" class="sig-img">
+                @endif
+                <div>{{ $idCardSettings->authority_name ?? 'Registrar' }}</div>
+            </div>
+        </div>
+    </div>
+    <!-- BACK -->
+    <div class="card">
+        <div class="front-header">
+            <div class="logo" style="width: {{ $idCardSettings->organization_logo_width ?? 28 }}px; height: {{ $idCardSettings->organization_logo_height ?? 28 }}px;">
+                @if($idCardSettings?->organization_logo)
+                    <img src="{{ asset('storage/' . $idCardSettings->organization_logo) }}" alt="{{ $idCardSettings->organization_name_en ?? $idCardSettings->organization_name }}">
+                @endif
+            </div>
+            <div class="org">
+                <div class="bn" style="font-size: {{ $idCardSettings->organization_name_font_size ?? 13 }}px;">{{ $idCardSettings->organization_name }}</div>
+                <div class="en">{{ $idCardSettings->organization_name_en }}</div>
+            </div>
+        </div>
+        <div class="back-body">
+            <div class="kv"><div class="k">P.F. No.</div><div>: {{ $nuSmartCard->pf_number }}</div></div>
+            <div class="kv"><div class="k">Mobile No.</div><div>: {{ $nuSmartCard->mobile_number }}</div></div>
+            <div class="kv"><div class="k">Blood Group</div><div>: {{ $nuSmartCard->blood?->name }}</div></div>
+            <div class="kv"><div class="k">Address</div><div>: {{ $nuSmartCard->present_address }}</div></div>
+            <div class="kv push-down"><div class="k">Emergency Contact</div><div>: {{ $nuSmartCard->emergency_contact }}</div></div>
+            <div class="kv"><div class="k">Valid Up to</div><div>: {{ \App\Helpers\DateHelpers::dateFormat($nuSmartCard->prl_date, 'd-m-Y') }}</div></div>
+            <div class="note">{{ $idCardSettings->back_footer }}</div>
+        </div>
+        <div class="barcode">{{ $nuSmartCard->id_card_number }}</div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ Route::group(['prefix' => '/dashboard', 'middleware' => 'auth'], function () {
     Route::resource('nu-smart-card', DashboardController::class);
     Route::get('nu-smart-card/{id}/card', [DashboardController::class, 'card'])->name('nu-smart-card.card');
     Route::get('view-pdf', [DashboardController::class, 'getPdfData'])->name('view-pdf');
+    Route::get('all-mastercard-download', [DashboardController::class, 'downloadAllMastercard'])->name('nu-smart-card.all-mastercard');
     Route::get('single-pdf/{id}', [DashboardController::class, 'getSinglePdfData'])->name('single-pdf');
     Route::get('export-word', [DashboardController::class, 'exportWord'])->name('export-word');
 


### PR DESCRIPTION
## Summary
- Add controller action and route to export all smart ID cards as a single legal-sized PDF
- Provide blade templates for rendering multiple card fronts and backs
- Add "All Mastercard Download" button to smart card list

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af8bdbd36c8326909214652a31c79e