### PR TITLE
Guard against empty HTML in DashboardController PDF export

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -544,9 +544,10 @@ class DashboardController extends Controller
         }
 
         $idCardSettings = IdCardSetting::first();
-        $html = view('nu-smart-card.all_mastercard_pdf', compact('nuSmartCards', 'idCardSettings'))->render();
 
-        if (!is_string($html) || trim($html) === '') {
+        // Ensure the rendered HTML is a non-empty string before passing to mPDF
+        $html = (string) view('nu-smart-card.all_mastercard_pdf', compact('nuSmartCards', 'idCardSettings'))->render();
+        if ($html === '') {
             return back()->with('error', 'Unable to generate PDF for ID cards.');
         }
 


### PR DESCRIPTION
## Summary
- Cast rendered view to string and validate it's not empty before generating PDF to avoid uninitialized string offset

## Testing
- `composer install --no-interaction --no-progress` *(failed: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af8fc0382083269c07dbf6ddbbfff8