### PR TITLE
Handle empty HTML when generating all ID card PDFs

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -548,8 +548,13 @@ class DashboardController extends Controller
             return back()->with('error', 'ID card settings are missing.');
         }
 
-        // Render the view and ensure we have a valid, non-empty string before passing to mPDF
-        $html = view('nu-smart-card.all_mastercard_pdf', compact('nuSmartCards', 'idCardSettings'))->render();
+        // Render the view safely and ensure we have a valid, non-empty string before passing to mPDF
+        try {
+            $html = view('nu-smart-card.all_mastercard_pdf', compact('nuSmartCards', 'idCardSettings'))->render();
+        } catch (\Throwable $e) {
+            return back()->with('error', 'Unable to generate PDF for ID cards.');
+        }
+
         if (!is_string($html) || trim($html) === '') {
             return back()->with('error', 'Unable to generate PDF for ID cards.');
         }


### PR DESCRIPTION
## Summary
- Safely render the `all_mastercard_pdf` view and guard against empty/invalid HTML before generating ID card PDFs

## Testing
- `php -l app/Http/Controllers/DashboardController.php`
- `composer install --no-interaction --no-progress` *(failed: curl error 56 CONNECT tunnel failed)*
- `./vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af96bf8e708326a19657576ff28977