### PR TITLE
Use SVG QR codes to avoid Imagick dependency

### DIFF
--- a/app/Http/Controllers/IdCardSettingController.php
+++ b/app/Http/Controllers/IdCardSettingController.php
@@ -62,7 +62,7 @@ class IdCardSettingController extends Controller
             'name'  => $user->name,
             'email' => $user->email,
         ]);
-        $qrCode = QrCode::format('png')->size(200)->generate($qrData);
+        $qrCode = QrCode::format('svg')->size(200)->generate($qrData);
 
         return view('id_card.show', compact('settings', 'user', 'qrCode'));
     }

--- a/resources/views/id_card/show.blade.php
+++ b/resources/views/id_card/show.blade.php
@@ -9,7 +9,7 @@
     @endif
     <h3>{{ $user->name }}</h3>
 
-    <img src="data:image/png;base64,{{ base64_encode($qrCode) }}" class="qr-code">
+    <img src="data:image/svg+xml;base64,{{ base64_encode($qrCode) }}" class="qr-code">
 
     @if($settings?->authority_signature)
         <img src="{{ asset('storage/' . $settings->authority_signature) }}" class="authority-logo">

--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -184,7 +184,7 @@
           'organization'=> $idCardSettings->organization_name ?? ''
         ]);
         $qrCode = base64_encode(
-          QrCode::format('png')->size(50)->errorCorrection('H')->generate($qrData)
+          QrCode::format('svg')->size(50)->errorCorrection('H')->generate($qrData)
         );
       @endphp
       <div class="footer">
@@ -193,7 +193,7 @@
         <div>Card Holder</div>
       </div>
 
-      <img src="data:image/png;base64,{{ $qrCode }}" alt="QR" class="qr">
+      <img src="data:image/svg+xml;base64,{{ $qrCode }}" alt="QR" class="qr">
 
       <div class="sig">
         @if($idCardSettings?->authority_signature)

--- a/resources/views/nu-smart-card/partials/id-card.blade.php
+++ b/resources/views/nu-smart-card/partials/id-card.blade.php
@@ -31,7 +31,7 @@
                 'organization'=> $idCardSettings->organization_name ?? ''
             ]);
             $qrCode = base64_encode(
-                QrCode::format('png')->size(50)->errorCorrection('H')->generate($qrData)
+                QrCode::format('svg')->size(50)->errorCorrection('H')->generate($qrData)
             );
         @endphp
         <div class="footer">
@@ -39,7 +39,7 @@
                 <img src="{{ asset('uploads/signature/' . $nuSmartCard->signature) }}" alt="Card Holder" class="sig-img">
                 <div>Card Holder</div>
             </div>
-            <img src="data:image/png;base64,{{ $qrCode }}" alt="QR" class="qr">
+            <img src="data:image/svg+xml;base64,{{ $qrCode }}" alt="QR" class="qr">
             <div class="sig">
                 @if($idCardSettings?->authority_signature)
                     <img src="{{ asset('storage/' . $idCardSettings->authority_signature) }}" alt="{{ $idCardSettings->authority_name ?? 'Registrar' }}" class="sig-img">


### PR DESCRIPTION
## Summary
- Generate QR codes as SVG rather than PNG to remove Imagick requirement
- Update blade templates to embed SVG QR codes

## Testing
- `composer install --no-progress --no-scripts` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68afa39963d483269a7fccf08a770bb6