### PR TITLE
Add home page sections and secure ID card listing

### DIFF
--- a/app/Http/Controllers/NuSmartCardController.php
+++ b/app/Http/Controllers/NuSmartCardController.php
@@ -172,7 +172,7 @@ class NuSmartCardController extends Controller
     {
         $nuSmartCards = NuSmartCard::with(['designation', 'department', 'blood'])
             ->orderBy('order_position', 'asc')
-            ->get();
+            ->paginate(6);
         $idCardSettings = IdCardSetting::first();
         return view('nu-smart-card.all_cards', compact('nuSmartCards', 'idCardSettings'));
     }

--- a/resources/views/frontend/index.blade.php
+++ b/resources/views/frontend/index.blade.php
@@ -1,14 +1,74 @@
 @extends('layouts.base', ['subtitle' => 'Home'])
 
-@section('body-attribute')
-    class="authentication-bg"
-@endsection
-
 @section('content')
-    <div class="flex-box flex-column">
-        <h1 class="align-items-center align-content-center">National University</h1>
-        <div>
-            <a class="btn btn-sm btn-primary" href="{{ route('login') }}">Login</a>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <div class="container">
+            <a class="navbar-brand" href="{{ route('home') }}">National University</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link" href="#services">Services</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#works">Our Work</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ route('nu-smart-card.pf-form') }}">ID Card Search</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ route('login') }}">Login</a></li>
+                </ul>
+            </div>
         </div>
-    </div>
+    </nav>
+
+    <section class="py-5 text-center bg-light">
+        <div class="container">
+            <h1 class="display-4">Welcome to National University</h1>
+            <p class="lead">Discover our services and recent work.</p>
+        </div>
+    </section>
+
+    <section id="services" class="py-5">
+        <div class="container">
+            <h2 class="mb-4 text-center">Our Services</h2>
+            <div class="row text-center">
+                <div class="col-md-3 mb-3">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">Service One</h5>
+                            <p class="card-text">Brief description of service one.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3 mb-3">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">Service Two</h5>
+                            <p class="card-text">Brief description of service two.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3 mb-3">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">Service Three</h5>
+                            <p class="card-text">Brief description of service three.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3 mb-3">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">Service Four</h5>
+                            <p class="card-text">Brief description of service four.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="works" class="py-5 bg-light">
+        <div class="container">
+            <h2 class="mb-4 text-center">Our Work</h2>
+            <p class="text-center">Showcase of our recent projects and achievements.</p>
+        </div>
+    </section>
 @endsection

--- a/resources/views/nu-smart-card/all_cards.blade.php
+++ b/resources/views/nu-smart-card/all_cards.blade.php
@@ -144,6 +144,9 @@
 <div class="no-print">
     <a href="{{ route('nu-smart-card.all-cards.pdf') }}" style="padding:8px 12px;background:#2563eb;color:#fff;border-radius:4px;text-decoration:none;">Download PDF</a>
     <button onclick="window.print()" style="padding:8px 12px;background:#4b5563;color:#fff;border:none;border-radius:4px;">Print</button>
+    <div style="margin-top:10px;">
+        {{ $nuSmartCards->links('pagination::bootstrap-5') }}
+    </div>
 </div>
 <div class="sheets">
     @foreach($nuSmartCards as $nuSmartCard)

--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -14,6 +14,8 @@
       --border:#e5e7eb;
     }
     *{ box-sizing:border-box; }
+    .no-print{margin-bottom:10px;}
+    @media print{.no-print{display:none;}}
     .back-body {
         padding: 10px;
         display: flex;
@@ -148,6 +150,9 @@
 </head>
 <body>
 @php use SimpleSoftwareIO\QrCode\Facades\QrCode; @endphp
+<div class="no-print">
+  <button onclick="window.print()" style="padding:8px 12px;background:#4b5563;color:#fff;border:none;border-radius:4px;">Print</button>
+</div>
 <div class="sheet">
     <!-- FRONT -->
     <div class="card">

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,8 +68,11 @@ Route::get('/nu-smart-card/search', [NuSmartCardController::class, 'search'])->n
 Route::get('/view-data', [NuSmartCardController::class, 'viewData'])->name('view-data');
 Route::get('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfForm'])->name('nu-smart-card.pf-form');
 Route::post('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfShow'])->name('nu-smart-card.pf-show');
-Route::get('/nu-smart-card/all-cards', [NuSmartCardController::class, 'allCards'])->name('nu-smart-card.all-cards');
-Route::get('/nu-smart-card/all-cards/pdf', [NuSmartCardController::class, 'downloadAllCardsPdf'])->name('nu-smart-card.all-cards.pdf');
+
+Route::middleware('auth')->group(function () {
+    Route::get('/nu-smart-card/all-cards', [NuSmartCardController::class, 'allCards'])->name('nu-smart-card.all-cards');
+    Route::get('/nu-smart-card/all-cards/pdf', [NuSmartCardController::class, 'downloadAllCardsPdf'])->name('nu-smart-card.all-cards.pdf');
+});
 
 Route::get('/id-card/{user}', [IdCardSettingController::class, 'show']);
 


### PR DESCRIPTION
## Summary
- Build a simple public home page with menu, hero, services and work sections, including link to ID card search
- Protect all ID card listing routes behind authentication and paginate six per page
- Add print buttons and pagination styling for ID card pages

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: GitHub 403 requiring authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e334825483268910e5840f68db2f