### PR TITLE
Add admin ID-card menu with PDF download

### DIFF
--- a/resources/views/layouts/partials/sidebar.blade.php
+++ b/resources/views/layouts/partials/sidebar.blade.php
@@ -41,6 +41,9 @@
                               <a class="sub-nav-link" href="{{ route ('nu-smart-card.index') }}">All List</a>
                           </li>
                           <li class="sub-nav-item">
+                              <a class="sub-nav-link" href="{{ route('nu-smart-card.all-cards') }}">All ID Cards</a>
+                          </li>
+                          <li class="sub-nav-item">
                               <a class="sub-nav-link" href="{{ route ('blood-group.index') }}">Blood Group</a>
                           </li>
                           <li class="sub-nav-item">

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,8 @@ Route::group(['prefix' => '/dashboard', 'middleware' => 'auth'], function () {
     Route::get('all-mastercard-download', [DashboardController::class, 'downloadAllMastercard'])->name('nu-smart-card.all-mastercard');
     Route::get('single-pdf/{id}', [DashboardController::class, 'getSinglePdfData'])->name('single-pdf');
     Route::get('export-word', [DashboardController::class, 'exportWord'])->name('export-word');
+    Route::get('nu-smart-card/all-cards', [NuSmartCardController::class, 'allCards'])->name('nu-smart-card.all-cards');
+    Route::get('nu-smart-card/all-cards/pdf', [NuSmartCardController::class, 'downloadAllCardsPdf'])->name('nu-smart-card.all-cards.pdf');
 
     // Blood Group
     Route::resource('blood-group', BloodGroupController::class);
@@ -68,11 +70,6 @@ Route::get('/nu-smart-card/search', [NuSmartCardController::class, 'search'])->n
 Route::get('/view-data', [NuSmartCardController::class, 'viewData'])->name('view-data');
 Route::get('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfForm'])->name('nu-smart-card.pf-form');
 Route::post('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfShow'])->name('nu-smart-card.pf-show');
-
-Route::middleware('auth')->group(function () {
-    Route::get('/nu-smart-card/all-cards', [NuSmartCardController::class, 'allCards'])->name('nu-smart-card.all-cards');
-    Route::get('/nu-smart-card/all-cards/pdf', [NuSmartCardController::class, 'downloadAllCardsPdf'])->name('nu-smart-card.all-cards.pdf');
-});
 
 Route::get('/id-card/{user}', [IdCardSettingController::class, 'show']);
 


### PR DESCRIPTION
## Summary
- add routes to display and export all ID cards
- link new "All ID Cards" page from Nu Smart Card admin menu

## Testing
- `php artisan test` *(fails: Failed to open stream: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e5f427b08326aeb638186615de66