### PR TITLE
Set QR code size to 40x40 pixels

### DIFF
--- a/app/Http/Controllers/IdCardSettingController.php
+++ b/app/Http/Controllers/IdCardSettingController.php
@@ -62,7 +62,7 @@ class IdCardSettingController extends Controller
             'name'  => $user->name,
             'email' => $user->email,
         ]);
-        $qrCode = QrCode::format('svg')->size(200)->generate($qrData);
+        $qrCode = QrCode::format('svg')->size(40)->generate($qrData);
 
         return view('id_card.show', compact('settings', 'user', 'qrCode'));
     }

--- a/resources/views/nu-smart-card/all_cards.blade.php
+++ b/resources/views/nu-smart-card/all_cards.blade.php
@@ -106,8 +106,8 @@
             margin-top:auto;
         }
         .qr{
-            width:50px;
-            height:50px;
+            width:40px;
+            height:40px;
             object-fit:contain;
             border:1px solid var(--border);
             border-radius:4px;

--- a/resources/views/nu-smart-card/all_mastercard_pdf.blade.php
+++ b/resources/views/nu-smart-card/all_mastercard_pdf.blade.php
@@ -108,8 +108,8 @@
             margin-top:auto;
         }
         .qr{
-            width:50px;
-            height:50px;
+            width:40px;
+            height:40px;
             object-fit:contain;
             border:1px solid var(--border);
             border-radius:4px;

--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -109,8 +109,8 @@
         padding: 6px 8px 12px;
     }
     .qr{
-      width:50px;
-      height:50px;
+      width:40px;
+      height:40px;
       object-fit:contain;
       border:1px solid var(--border);
       border-radius:4px;
@@ -185,7 +185,7 @@
           'organization'=> $idCardSettings->organization_name ?? ''
         ]);
         $qrCode = base64_encode(
-          QrCode::format('svg')->size(50)->errorCorrection('H')->generate($qrData)
+          QrCode::format('svg')->size(40)->errorCorrection('H')->generate($qrData)
         );
       @endphp
       <div class="footer">

--- a/resources/views/nu-smart-card/partials/id-card.blade.php
+++ b/resources/views/nu-smart-card/partials/id-card.blade.php
@@ -34,7 +34,7 @@
                 'organization'=> $idCardSettings->organization_name ?? ''
             ]);
             $qrCode = base64_encode(
-                QrCode::format('svg')->size(50)->errorCorrection('H')->generate($qrData)
+                QrCode::format('svg')->size(40)->errorCorrection('H')->generate($qrData)
             );
         @endphp
         <div class="footer">


### PR DESCRIPTION
## Summary
- Generate 40px QR codes in ID card controller and views
- Align QR code styling to 40x40px across smart card templates

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e907e49c8326b86f5237974badb8