### PR TITLE
Embed extra details in ID card QR codes

### DIFF
--- a/app/Http/Controllers/IdCardSettingController.php
+++ b/app/Http/Controllers/IdCardSettingController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\IdCardSetting;
-use App\Models\User;
+use App\Models\NuSmartCard;
 use Illuminate\Http\Request;
 use SimpleSoftwareIO\QrCode\Facades\QrCode;
 
@@ -52,19 +52,20 @@ class IdCardSettingController extends Controller
     }
 
     /**
-     * Display an ID card for the given user with QR code.
+     * Display an ID card for the given NuSmartCard with QR code.
      */
-    public function show(User $user)
+    public function show(NuSmartCard $nuSmartCard)
     {
         $settings = IdCardSetting::first();
         $qrData = json_encode([
-            'id'    => $user->id,
-            'name'  => $user->name,
-            'email' => $user->email,
+            'name'        => $nuSmartCard->name,
+            'designation' => $nuSmartCard->designation?->name,
+            'mobile'      => $nuSmartCard->mobile_number,
+            'organization'=> $settings->organization_name ?? '',
         ]);
         $qrCode = QrCode::format('svg')->size(40)->generate($qrData);
 
-        return view('id_card.show', compact('settings', 'user', 'qrCode'));
+        return view('id_card.show', compact('settings', 'nuSmartCard', 'qrCode'));
     }
 }
 

--- a/resources/views/id_card/show.blade.php
+++ b/resources/views/id_card/show.blade.php
@@ -7,7 +7,7 @@
     @if($settings?->organization_name_en)
         <h3>{{ $settings->organization_name_en }}</h3>
     @endif
-    <h3>{{ $user->name }}</h3>
+    <h3>{{ $nuSmartCard->name }}</h3>
 
     <img src="data:image/svg+xml;base64,{{ base64_encode($qrCode) }}" class="qr-code">
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,6 +71,6 @@ Route::get('/view-data', [NuSmartCardController::class, 'viewData'])->name('view
 Route::get('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfForm'])->name('nu-smart-card.pf-form');
 Route::post('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfShow'])->name('nu-smart-card.pf-show');
 
-Route::get('/id-card/{user}', [IdCardSettingController::class, 'show']);
+Route::get('/id-card/{nuSmartCard}', [IdCardSettingController::class, 'show']);
 
 


### PR DESCRIPTION
## Summary
- generate NuSmartCard QR codes with name, designation, mobile, and organization info
- render ID cards using NuSmartCard data
- expose ID card view through `/id-card/{nuSmartCard}` route

## Testing
- `php -l app/Http/Controllers/IdCardSettingController.php`
- `php artisan test` *(fails: Failed to open stream: No such file or directory)*
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b11cf94fe88326b2cafb471a6ba463