### PR TITLE
Increase QR code size for better scanning

### DIFF
--- a/app/Http/Controllers/IdCardSettingController.php
+++ b/app/Http/Controllers/IdCardSettingController.php
@@ -63,7 +63,10 @@ class IdCardSettingController extends Controller
             'mobile'      => $nuSmartCard->mobile_number,
             'organization'=> $settings->organization_name ?? '',
         ]);
-        $qrCode = QrCode::format('svg')->size(40)->generate($qrData);
+        $qrCode = QrCode::format('svg')
+            ->size(200)
+            ->errorCorrection('H')
+            ->generate($qrData);
 
         return view('id_card.show', compact('settings', 'nuSmartCard', 'qrCode'));
     }

--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -185,7 +185,7 @@
           'organization'=> $idCardSettings->organization_name ?? ''
         ]);
         $qrCode = base64_encode(
-          QrCode::format('svg')->size(40)->errorCorrection('H')->generate($qrData)
+          QrCode::format('svg')->size(200)->errorCorrection('H')->generate($qrData)
         );
       @endphp
       <div class="footer">

--- a/resources/views/nu-smart-card/partials/id-card.blade.php
+++ b/resources/views/nu-smart-card/partials/id-card.blade.php
@@ -34,7 +34,7 @@
                 'organization'=> $idCardSettings->organization_name ?? ''
             ]);
             $qrCode = base64_encode(
-                QrCode::format('svg')->size(40)->errorCorrection('H')->generate($qrData)
+                QrCode::format('svg')->size(200)->errorCorrection('H')->generate($qrData)
             );
         @endphp
         <div class="footer">


### PR DESCRIPTION
## Summary
- Enlarge generated QR codes and enable high error correction for scannability.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b122c22f9883269cdc855084e3f45d