### PR TITLE
Add ID card PDF download option

### DIFF
--- a/resources/views/nu-smart-card/card_pdf.blade.php
+++ b/resources/views/nu-smart-card/card_pdf.blade.php
@@ -14,8 +14,6 @@
             --border:#e5e7eb;
         }
         *{ box-sizing:border-box; }
-        .no-print{margin-bottom:10px;}
-        @media print{.no-print{display:none;}}
         .back-body {
             padding: 10px;
             display: flex;
@@ -150,14 +148,6 @@
 </head>
 <body>
 @php use SimpleSoftwareIO\QrCode\Facades\QrCode; @endphp
-<div class="no-print">
-    <button onclick="window.print()" style="padding:8px 12px;background:#4b5563;color:#fff;border:none;border-radius:4px;">Print</button>
-    <form action="{{ route('nu-smart-card.pf-show.pdf') }}" method="POST" style="display:inline;">
-        @csrf
-        <input type="hidden" name="pf_number" value="{{ $nuSmartCard->pf_number }}">
-        <button type="submit" style="padding:8px 12px;background:#1f2937;color:#fff;border:none;border-radius:4px;">Download PDF</button>
-    </form>
-</div>
 <div class="sheet">
     <!-- FRONT -->
     <div class="card">

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,6 +70,7 @@ Route::get('/nu-smart-card/search', [NuSmartCardController::class, 'search'])->n
 Route::get('/view-data', [NuSmartCardController::class, 'viewData'])->name('view-data');
 Route::get('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfForm'])->name('nu-smart-card.pf-form');
 Route::post('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfShow'])->name('nu-smart-card.pf-show');
+Route::post('/nu-smart-card/pf-search/pdf', [NuSmartCardController::class, 'pfShowPdf'])->name('nu-smart-card.pf-show.pdf');
 
 Route::get('/id-card/{nuSmartCard}', [IdCardSettingController::class, 'show']);
 


### PR DESCRIPTION
## Summary
- allow users to download an ID card as a PDF
- add dedicated PDF view and controller method
- expose new route and button for PDF downloads

## Testing
- ⚠️ `php artisan test` *(fails: missing vendor autoload, composer install blocked by 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1471159208326a0bc9631739fd135