### PR TITLE
Use streamed responses for PDF downloads

### DIFF
--- a/app/Http/Controllers/NuSmartCardController.php
+++ b/app/Http/Controllers/NuSmartCardController.php
@@ -208,9 +208,13 @@ class NuSmartCardController extends Controller
             return back()->with('error', 'Unable to generate PDF for the ID card.');
         }
 
-        ob_clean();
-        flush();
-        return $mpdf->Output('id-card.pdf', 'I');
+        $pdfContent = $mpdf->Output('', 'S');
+
+        return response()->streamDownload(
+            fn () => print($pdfContent),
+            'id-card.pdf',
+            ['Content-Type' => 'application/pdf']
+        );
     }
 
     /**
@@ -272,8 +276,12 @@ class NuSmartCardController extends Controller
             return back()->with('error', 'Unable to generate PDF for ID cards.');
         }
 
-        ob_clean();
-        flush();
-        return $mpdf->Output('all-id-cards.pdf', 'D');
+        $pdfContent = $mpdf->Output('', 'S');
+
+        return response()->streamDownload(
+            fn () => print($pdfContent),
+            'all-id-cards.pdf',
+            ['Content-Type' => 'application/pdf']
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Stream ID card PDF generation instead of calling `Output` directly
- Stream bulk ID card PDF downloads for proper headers

## Testing
- `composer install --no-ansi` *(fails: CONNECT tunnel failed and requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68b148fe9d408326a4b31de14992fe11