### PR TITLE
Add dark mode toggle and improve ID card PDF download

### DIFF
--- a/app/Http/Controllers/NuSmartCardController.php
+++ b/app/Http/Controllers/NuSmartCardController.php
@@ -215,11 +215,10 @@ class NuSmartCardController extends Controller
 
         $pdfContent = $mpdf->Output('', 'S');
 
-        return response()->streamDownload(
-            fn () => print($pdfContent),
-            'id-card.pdf',
-            ['Content-Type' => 'application/pdf']
-        );
+        return response($pdfContent, 200)->withHeaders([
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'attachment; filename="id-card.pdf"',
+        ]);
     }
 
     /**

--- a/resources/views/frontend/nuSmartCard/pf.blade.php
+++ b/resources/views/frontend/nuSmartCard/pf.blade.php
@@ -24,12 +24,12 @@
         }
         .sheet{
             display:grid;
-            grid-template-columns: 5.5cm 5.5cm;
+            grid-template-columns: 5.4cm 5.4cm;
             gap: 20px;
         }
         .card {
-            width: 5.5cm;
-            height: 8.7cm;
+            width: 5.4cm;
+            height: 8.56cm;
             background: #fff;
             border-radius: 14px;
             border: 1px solid var(--border);
@@ -140,7 +140,7 @@
         }
         @media print{
             body{background:#fff;padding:0;}
-            .sheet{gap:0;grid-template-columns:5.5cm 5.5cm;justify-content:space-between;padding:0 1cm;}
+            .sheet{gap:0;grid-template-columns:5.4cm 5.4cm;justify-content:space-between;padding:0 1cm;}
             .card{box-shadow:none;margin:0;}
         }
     </style>
@@ -184,13 +184,10 @@
         @isset($nuSmartCard)
             <div class="d-flex flex-column align-items-center">
                 @include('nu-smart-card.partials.id-card', ['nuSmartCard' => $nuSmartCard, 'idCardSettings' => $idCardSettings])
+                @php $pdfUrl = route('nu-smart-card.pf-show.pdf', ['pf_number' => $nuSmartCard->pf_number]); @endphp
                 <div class="no-print mt-3 text-center">
                     <button class="btn btn-secondary me-2" onclick="window.print()">Print</button>
-                    <form action="{{ route('nu-smart-card.pf-show.pdf') }}" method="POST" class="d-inline">
-                        @csrf
-                        <input type="hidden" name="pf_number" value="{{ $nuSmartCard->pf_number }}">
-                        <button type="submit" class="btn btn-dark">Download PDF</button>
-                    </form>
+                    <a href="{{ $pdfUrl }}" class="btn btn-dark" target="_blank">Download PDF</a>
                 </div>
             </div>
         @endisset

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -8,6 +8,9 @@
 </head>
 
 <body @yield('body-attribute')>
+    <button id="light-dark-mode" class="btn btn-sm btn-outline-secondary position-fixed top-0 end-0 m-3">
+        Toggle Theme
+    </button>
 
     @yield('content')
 

--- a/resources/views/nu-smart-card/all_cards.blade.php
+++ b/resources/views/nu-smart-card/all_cards.blade.php
@@ -23,12 +23,12 @@
         }
         .sheet{
             display:grid;
-            grid-template-columns: 5.5cm 5.5cm;
+            grid-template-columns: 5.4cm 5.4cm;
             gap: 20px;
         }
         .card{
-            width:5.5cm;
-            height:8.7cm;
+            width:5.4cm;
+            height:8.56cm;
             background:#fff;
             border-radius:14px;
             border:1px solid var(--border);

--- a/resources/views/nu-smart-card/all_mastercard_pdf.blade.php
+++ b/resources/views/nu-smart-card/all_mastercard_pdf.blade.php
@@ -25,12 +25,12 @@
         }
         .sheet{
             display:grid;
-            grid-template-columns: 5.5cm 5.5cm;
+            grid-template-columns: 5.4cm 5.4cm;
             gap: 20px;
         }
         .card{
-            width:5.5cm;
-            height:8.7cm;
+            width:5.4cm;
+            height:8.56cm;
             background:#fff;
             border-radius:14px;
             border:1px solid var(--border);

--- a/resources/views/nu-smart-card/card.blade.php
+++ b/resources/views/nu-smart-card/card.blade.php
@@ -27,12 +27,12 @@
         }
         .sheet{
             display:grid;
-            grid-template-columns: 5.5cm 5.5cm;
+            grid-template-columns: 5.4cm 5.4cm;
             gap: 20px;
         }
         .card {
-            width: 5.5cm;
-            height: 8.7cm;
+            width: 5.4cm;
+            height: 8.56cm;
             background: #fff;
             border-radius: 14px;
             border: 1px solid var(--border);
@@ -143,20 +143,17 @@
         }
         @media print{
             body{background:#fff;padding:0;}
-            .sheet{gap:0;grid-template-columns:5.5cm 5.5cm;justify-content:space-between;padding:0 1cm;}
+            .sheet{gap:0;grid-template-columns:5.4cm 5.4cm;justify-content:space-between;padding:0 1cm;}
             .card{box-shadow:none;margin:0;}
         }
     </style>
 </head>
 <body>
 @php use SimpleSoftwareIO\QrCode\Facades\QrCode; @endphp
+@php $pdfUrl = route('nu-smart-card.pf-show.pdf', ['pf_number' => $nuSmartCard->pf_number]); @endphp
 <div class="no-print">
     <button onclick="window.print()" style="padding:8px 12px;background:#4b5563;color:#fff;border:none;border-radius:4px;">Print</button>
-    <form action="{{ route('nu-smart-card.pf-show.pdf') }}" method="POST" style="display:inline;">
-        @csrf
-        <input type="hidden" name="pf_number" value="{{ $nuSmartCard->pf_number }}">
-        <button type="submit" style="padding:8px 12px;background:#1f2937;color:#fff;border:none;border-radius:4px;">Download PDF</button>
-    </form>
+    <a href="{{ $pdfUrl }}" style="padding:8px 12px;background:#1f2937;color:#fff;border:none;border-radius:4px;" target="_blank">Download PDF</a>
 </div>
 <div class="sheet">
     <!-- FRONT -->

--- a/resources/views/nu-smart-card/card_pdf.blade.php
+++ b/resources/views/nu-smart-card/card_pdf.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>ID Card 5.5cm x 8.7cm</title>
+    <title>ID Card 5.4cm x 8.56cm</title>
     <style>
         @page { size: A4; margin: 1cm; }
         :root{
@@ -25,12 +25,12 @@
         }
         .sheet{
             display:grid;
-            grid-template-columns: 5.5cm 5.5cm;
+            grid-template-columns: 5.4cm 5.4cm;
             gap: 20px;
         }
         .card {
-            width: 5.5cm;
-            height: 8.7cm;
+            width: 5.4cm;
+            height: 8.56cm;
             background: #fff;
             border-radius: 14px;
             border: 1px solid var(--border);
@@ -141,7 +141,7 @@
         }
         @media print{
             body{background:#fff;padding:0;}
-            .sheet{gap:0;grid-template-columns:5.5cm 5.5cm;justify-content:space-between;padding:0 1cm;}
+            .sheet{gap:0;grid-template-columns:5.4cm 5.4cm;justify-content:space-between;padding:0 1cm;}
             .card{box-shadow:none;margin:0;}
         }
     </style>

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,7 +70,7 @@ Route::get('/nu-smart-card/search', [NuSmartCardController::class, 'search'])->n
 Route::get('/view-data', [NuSmartCardController::class, 'viewData'])->name('view-data');
 Route::get('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfForm'])->name('nu-smart-card.pf-form');
 Route::post('/nu-smart-card/pf-search', [NuSmartCardController::class, 'pfShow'])->name('nu-smart-card.pf-show');
-Route::post('/nu-smart-card/pf-search/pdf', [NuSmartCardController::class, 'pfShowPdf'])->name('nu-smart-card.pf-show.pdf');
+Route::get('/nu-smart-card/pf-search/pdf', [NuSmartCardController::class, 'pfShowPdf'])->name('nu-smart-card.pf-show.pdf');
 
 Route::get('/id-card/{nuSmartCard}', [IdCardSettingController::class, 'show']);
 


### PR DESCRIPTION
## Summary
- add global dark/light mode toggle button
- fix ID card PDF download by using GET and proper headers
- enforce consistent physical dimensions for ID cards

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-progress` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68b34ff7fcb48326ad27bbb66f193242