### PR TITLE
Add theme toggle icons and refine ID card printing

### DIFF
--- a/resources/views/frontend/nuSmartCard/pf.blade.php
+++ b/resources/views/frontend/nuSmartCard/pf.blade.php
@@ -140,6 +140,8 @@
         }
         @media print{
             body{background:#fff;padding:0;}
+            nav, .no-print, form, h1, .alert{display:none!important;}
+            .container{padding:0!important;margin:0!important;}
             .sheet{gap:0;grid-template-columns:5.4cm 5.4cm;justify-content:space-between;padding:0 1cm;}
             .card{box-shadow:none;margin:0;}
         }
@@ -183,7 +185,9 @@
 
         @isset($nuSmartCard)
             <div class="d-flex flex-column align-items-center">
-                @include('nu-smart-card.partials.id-card', ['nuSmartCard' => $nuSmartCard, 'idCardSettings' => $idCardSettings])
+                <div class="print-area">
+                    @include('nu-smart-card.partials.id-card', ['nuSmartCard' => $nuSmartCard, 'idCardSettings' => $idCardSettings])
+                </div>
                 @php $pdfUrl = route('nu-smart-card.pf-show.pdf', ['pf_number' => $nuSmartCard->pf_number]); @endphp
                 <div class="no-print mt-3 text-center">
                     <button class="btn btn-secondary me-2" onclick="window.print()">Print</button>

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -5,11 +5,17 @@
     @include('layouts.partials/title-meta')
 
     @include('layouts.partials/head-css')
+    <style>
+        #light-dark-mode .dark-mode {display: none;}
+        [data-bs-theme="dark"] #light-dark-mode .light-mode {display: none;}
+        [data-bs-theme="dark"] #light-dark-mode .dark-mode {display: inline;}
+    </style>
 </head>
 
 <body @yield('body-attribute')>
     <button id="light-dark-mode" class="btn btn-sm btn-outline-secondary position-fixed top-0 end-0 m-3">
-        Toggle Theme
+        <iconify-icon icon="solar:moon-outline" class="fs-22 align-middle light-mode"></iconify-icon>
+        <iconify-icon icon="solar:sun-2-outline" class="fs-22 align-middle dark-mode"></iconify-icon>
     </button>
 
     @yield('content')


### PR DESCRIPTION
## Summary
- replace text theme toggle with sun/moon icons and css
- hide navigation and controls when printing ID cards

## Testing
- `npm run build`
- `php artisan test` *(fails: Failed opening required '/workspace/nu-project-Laravel/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b3542b4860832695e3bee4b812d20d