### PR TITLE
Add frontend navbar to NU Smart Card form

### DIFF
--- a/resources/views/nu-smart-card/create.blade.php
+++ b/resources/views/nu-smart-card/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.vertical', ['subtitle' => 'Nu Smart Card'])
+@extends('layouts.base', ['subtitle' => 'Nu Smart Card'])
 
 @section('css')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.13/cropper.min.css">
@@ -16,16 +16,34 @@
     </style>
 @endsection
 @section('content')
-    <div class="row row-cols-lg-1 gx-3">
-        <div class="col">
-            <div class="card">
-                <div class="card-header">
-                    <h5 class="card-title mb-0">Nu Smart Data Add</h5>
-                </div>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <div class="container">
+            <a class="navbar-brand" href="{{ route('home') }}">National University</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link" href="#services">Services</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#works">Our Work</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ route('nu-smart-card.pf-form') }}">ID Card Search</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ route('login') }}">Login</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
 
-                <div class="card-body">
-                    <form id="ajax-form" enctype="multipart/form-data">
-                        <div class="row row-cols-lg-2 gx-4">
+    <div class="container py-4">
+        <div class="row row-cols-lg-1 gx-3">
+            <div class="col">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Nu Smart Data Add</h5>
+                    </div>
+
+                    <div class="card-body">
+                        <form id="ajax-form" enctype="multipart/form-data">
+                            <div class="row row-cols-lg-2 gx-4">
                             <div>
                                 <div class="mb-3">
                                     <label for="name" class="form-label">Name</label>


### PR DESCRIPTION
## Summary
- Show the main site navbar on the NU Smart Card data entry form
- Switch the form layout to the base layout and wrap the content in a container

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403 while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b359fcd138832697aa87f169d16812