### PR TITLE
Fallback to default font for ID card PDFs

### DIFF
--- a/app/Http/Controllers/NuSmartCardController.php
+++ b/app/Http/Controllers/NuSmartCardController.php
@@ -197,8 +197,10 @@ class NuSmartCardController extends Controller
             return back()->with('error', 'Unable to generate PDF for the ID card.');
         }
 
+        $defaultFont = file_exists(public_path('fonts/nikosh.ttf')) ? 'nikosh' : 'dejavusans';
+
         $mpdf = new \Mpdf\Mpdf([
-            'default_font' => 'nikosh',
+            'default_font' => $defaultFont,
             'mode' => 'utf-8',
             'margin_left' => 5,
             'margin_right' => 5,
@@ -263,8 +265,10 @@ class NuSmartCardController extends Controller
             return back()->with('error', 'Unable to generate PDF for ID cards.');
         }
 
+        $defaultFont = file_exists(public_path('fonts/nikosh.ttf')) ? 'nikosh' : 'dejavusans';
+
         $mpdf = new \Mpdf\Mpdf([
-            'default_font' => 'nikosh',
+            'default_font' => $defaultFont,
             'mode' => 'utf-8',
             'margin_left' => 5,
             'margin_right' => 5,


### PR DESCRIPTION
## Summary
- Ensure PDF generation uses a valid font by falling back to `dejavusans` when `nikosh` is missing
- Apply font fallback to single and bulk ID card PDF downloads

## Testing
- `composer install --no-interaction` *(fails: curl error 56, CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b35b9714848326bcf021509334e3cb