### PR TITLE
Improve staff list table and action layout

### DIFF
--- a/resources/views/nu-smart-card/index.blade.php
+++ b/resources/views/nu-smart-card/index.blade.php
@@ -1,5 +1,12 @@
 @extends('layouts.vertical', ['subtitle' => 'Nu Smart Card'])
 @section('css')
+    <style>
+        .nu-action-group .btn {
+            display: flex;
+            align-items: center;
+            gap: .25rem;
+        }
+    </style>
 @endsection
 @section('content')
 
@@ -9,19 +16,21 @@
         <div class="card-header">
             <div class="flex-box justify-content-between align-items-center">
                 <h5 class="card-title">College Inspection Staff List</h5>
-                <div class="d-flex align-items-center">
-                    <input type="text" id="search" class="form-control form-control-sm me-2" placeholder="Search...">
-                    <a class="btn btn-sm btn-success me-2" href="{{ route('export-word') }}">Word Export</a>
-                    <a class="btn btn-sm btn-red me-2" target="_blank" href="{{ route('view-pdf') }}">PDF Download</a>
-                    <a class="btn btn-sm btn-red me-2" target="_blank" href="{{ route('nu-smart-card.all-mastercard') }}">All Mastercard Download</a>
-                    <a class="btn btn-sm btn-info" href="{{ route('nu-smart-card.create') }}">Add New</a>
+                <div class="d-flex align-items-center flex-wrap gap-2">
+                    <input type="text" id="search" class="form-control form-control-sm" placeholder="Search...">
+                    <div class="btn-group btn-group-sm nu-action-group" role="group" aria-label="Actions">
+                        <a class="btn btn-success" href="{{ route('export-word') }}"><i class="bx bxs-file-doc"></i> Word</a>
+                        <a class="btn btn-red" target="_blank" href="{{ route('view-pdf') }}"><i class="bx bxs-file-pdf"></i> PDF</a>
+                        <a class="btn btn-red" target="_blank" href="{{ route('nu-smart-card.all-mastercard') }}"><i class="bx bx-download"></i> All</a>
+                        <a class="btn btn-info" href="{{ route('nu-smart-card.create') }}"><i class="bx bx-plus"></i> Add</a>
+                    </div>
                 </div>
             </div>
         </div>
 
         <div class="card-body">
             <div class="table-responsive">
-                <table class="table table-centered">
+                <table class="table table-centered table-striped table-hover align-middle">
                     <thead>
                     <tr>
                         <th scope="col">#</th>

--- a/resources/views/nu-smart-card/partials/table-rows.blade.php
+++ b/resources/views/nu-smart-card/partials/table-rows.blade.php
@@ -7,11 +7,13 @@
         <td>{{ $nu->created_at->toDateString() }}</td>
         <td><img class="img-thumbnail img-fluid rounded mx-auto d-block w-25" alt="image" src="{!! asset('uploads/images/' . $nu->image)  !!}"></td>
         <td class="text-center">
-            <a href="{{ route('single-pdf', $nu->id) }}" class="btn btn-red btn-sm" target="_blank"><i class="bx bxs-file-pdf fs-4"></i></a>
-            <a href="{{ route('nu-smart-card.card', $nu->id) }}" class="btn btn-sm btn-info" target="_blank"><i class="bx bx-id-card fs-4"></i></a>
-            <a href="{{ route('nu-smart-card.show', $nu->id) }}" class="btn btn-primary btn-sm"><i class="bx bx-show fs-4"></i></a>
-            <a href="{{ route('nu-smart-card.edit', $nu->id) }}" class="btn btn-sm btn-green"><i class="bx bx-edit fs-4"></i></a>
-            <button data-url="{{ route('nu-smart-card.destroy', $nu->id) }}" class="btn btn-danger delete-btn btn-sm"><i class="bx bx-trash fs-4"></i></button>
+            <div class="btn-group btn-group-sm" role="group" aria-label="Row actions">
+                <a href="{{ route('single-pdf', $nu->id) }}" class="btn btn-red" target="_blank" title="PDF"><i class="bx bxs-file-pdf"></i></a>
+                <a href="{{ route('nu-smart-card.card', $nu->id) }}" class="btn btn-info" target="_blank" title="Card"><i class="bx bx-id-card"></i></a>
+                <a href="{{ route('nu-smart-card.show', $nu->id) }}" class="btn btn-primary" title="View"><i class="bx bx-show"></i></a>
+                <a href="{{ route('nu-smart-card.edit', $nu->id) }}" class="btn btn-green" title="Edit"><i class="bx bx-edit"></i></a>
+                <button data-url="{{ route('nu-smart-card.destroy', $nu->id) }}" class="btn btn-danger delete-btn" title="Delete"><i class="bx bx-trash"></i></button>
+            </div>
         </td>
     </tr>
 @empty


### PR DESCRIPTION
## Summary
- Enhance header with compact action button group and icons
- Style staff table with stripes and hover effects for better readability
- Group row action buttons for a cleaner layout

## Testing
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b476c4a4ac8326bd98cb1116c46b06