### PR TITLE
Fix single PDF generation

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -528,9 +528,13 @@ class DashboardController extends Controller
         $mpdf->watermark_font = 'DejaVuSansCondensed';
         $mpdf->watermarkTextAlpha = 0.1;
         $mpdf->WriteHTML($html);
-        ob_clean();
-        flush();
-        $mpdf->Output(Str::slug($data->name).'.pdf','I');
+
+        $pdfContent = $mpdf->Output('', 'S');
+
+        return response($pdfContent, 200)->withHeaders([
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'inline; filename="'.Str::slug($data->name).'.pdf"',
+        ]);
     }
 
     public function downloadAllMastercard()


### PR DESCRIPTION
## Summary
- return PDF content in single-ID view instead of writing directly to output to prevent header issues

## Testing
- `composer install --no-interaction --no-progress` *(fails: Failed to clone https://github.com/doctrine/inflector.git via https, ssh protocols, aborting)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b478fa177c83268ce6db8ab7dded9b